### PR TITLE
Project section updates

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -171,11 +171,11 @@ module.exports = {
             title: 'Project',
             path: '/project/',
             children: [
+              ['https://github.com/filecoin-project/specs', 'Specification'],
               [
                 'https://app.instagantt.com/shared/s/1152992274307505/latest',
                 'Roadmap'
               ],
-              ['https://github.com/filecoin-project/specs', 'Specifications'],
               ['https://research.filecoin.io/', 'Research'],
               '/project/related-projects',
               [

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -171,7 +171,6 @@ module.exports = {
             title: 'Project',
             path: '/project/',
             children: [
-              'project/history',
               [
                 'https://app.instagantt.com/shared/s/1152992274307505/latest',
                 'Roadmap'

--- a/docs/project/README.md
+++ b/docs/project/README.md
@@ -6,17 +6,13 @@ description: Learn about the history, roadmap, current status and more for Filec
 
 Curious about how it all got started, or where we're headed? Learn about the history, current state, and future trajectory of the Filecoin project here.
 
-## History of Filecoin
+## Filecoin specification
 
-Want to know how it all began? Learn the [history of the Filecoin project](/project/history/).
+View the [technical specification](https://github.com/filecoin-project/specs) for the Filecoin protocol and its associated subsystems.
 
 ## Roadmap
 
 The latest timing information is available in the [Filecoin Mainnet Roadmap](https://app.instagantt.com/shared/s/1152992274307505/latest).
-
-## Filecoin specification
-
-View the [technical specification](https://github.com/filecoin-project/specs) for the Filecoin protocol and its associated subsystems.
 
 ## Research
 

--- a/docs/project/history.md
+++ b/docs/project/history.md
@@ -1,9 +1,0 @@
----
-title: History
-sidebarDepth: 0
-description: Learn about the history of Filecoin.
----
-
-# History of the Filecoin project
-
-**TODO: Add contents**


### PR DESCRIPTION
- Removes history section (from sidebar, section readme, and markdown stub)
- Swap position of Specification & Roadmap sections, because the Spec link works a bit better as overview.
- Tiny nit: Remove "s" from end of "Specification" link.

With these edits, I believe the Project section is ready to publish. Please mention if anything else is needed.