### PR TITLE
update Algolia API key

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -22,8 +22,8 @@ module.exports = {
   },
   themeConfig: {
     algolia: {
-      apiKey: 'e6dcd48beb5db629bf77c892d38fa091', //TODO: replace
-      indexName: 'ipfs' // TODO: replace
+      apiKey: '6c3d7635474cdcd0a0aaf8ca397a4c44',
+      indexName: 'filecoin'
     },
     betaTestFormUrl:
       'https://docs.google.com/forms/d/1LVaD1B2uyW6Ff0jfU_iQ5mCeyQcHfyQO6BDD99XAgK0/viewform',


### PR DESCRIPTION
Setting up our Filecoin docs Algolia DocSearch instance (was previously using IPFS search terms, will now crawl our site every 24 hours)