### PR TITLE
Clarify localnet/devnet info

### DIFF
--- a/docs/how-to/build-interacting-with-the-network.md
+++ b/docs/how-to/build-interacting-with-the-network.md
@@ -14,19 +14,13 @@ You can run this node yourself or choose a hosted option. Running your own node 
 ## Local networks
 
 Here are some ways to spin up a mock version of the Filecoin network on your own machine(s), for quick testing and development:
-- [Filecoin Node Hosting Quick Start](https://paper.dropbox.com/doc/Filecoin-Node-Hosting-Quick-Start-7RBPjls1Bz6WLkT634NEN) for k8s and Docker
+- [Simple local devnet for lotus](https://lotu.sh/en+setup-local-dev-net)
 - [Containerized devnet using mocked sectorbuilder](https://github.com/textileio/lotus-devnet) (aka mocked mining)
 - [Additional containers & virtualization scripts](https://github.com/filecoin-project/docs/wiki#containers--virtualization)
 
-## Node APIs & API endpoints
-
-Coming soon.
-
 ## Running your own remote nodes or networks
 
-The same containerization scripts for [local networks](#local-networks) can also be used to run your own remote nodes or networks.
-
-TODO: Additional tips.
+- [Filecoin Node Hosting Quick Start](https://paper.dropbox.com/doc/Filecoin-Node-Hosting-Quick-Start-7RBPjls1Bz6WLkT634NEN) for remotely hosting your own node(s) using Kubernetes and Docker
 
 ## Testnet
 


### PR DESCRIPTION
- Adds lotus devnet link to "Local devnet" section.
- Moves "Filecoin Node Hosting" link to "Remote nodes" section
- Clean up TODOs and placeholder text