### PR TITLE
match width of homepage content to other pages

### DIFF
--- a/docs/.vuepress/theme/components/Home.vue
+++ b/docs/.vuepress/theme/components/Home.vue
@@ -183,11 +183,11 @@ export default {
 
 <style lang="stylus" scoped>
 .home .theme-default-content:not(.custom) {
-    margin: auto;
     padding: 2rem 2.5rem 6rem;
-    max-width: 920px;
-    background: no-repeat url("/images/main-page-background.png") 600px 34px;
-    background-size: 400px 480px;
+    max-width: 740px;
+    background: no-repeat url("/images/main-page-background.png");
+    background-position: 550px 34px;
+    background-size: 280px 336px;
 }
 .home .theme-default-content:not(.custom) > h1:first-child {
     font-weight: normal;
@@ -196,9 +196,10 @@ export default {
 .home {
     .intro {
         max-width: 500px;
+        margin-top: 3rem;
     }
     .grid {
-        margin-top: 6rem;
+        margin-top: 4rem;
         display: grid;
         grid-template-columns: 1fr 1fr;
         grid-auto-flow: row dense;
@@ -232,14 +233,20 @@ export default {
         color: black;
     }
 
-    @media (max-width: $MQMobile) {
+    @media (max-width: $MQNarrow) {
         .grid {
             grid-template-columns: 1fr;
-            grid-auto-rows: minmax(16rem, max-content);
+            /* grid-auto-rows: minmax(16rem, max-content); */
+            grid-auto-rows: auto;
+
         }
         .category {
             grid-column: auto !important;
             grid-row: auto !important;
+        }
+
+        .intro {
+          margin-top: 0;
         }
     }
 }


### PR DESCRIPTION
This PR updates the homepage width to be consistent with other pages, including shrinking the background image to maintain a similar effect. It also fixes breakpoints so the grid boxes don't get excessively narrow when shrinking the screen. 

New homepage design on desktop: 
![image](https://user-images.githubusercontent.com/19171465/80729420-40062380-8ad6-11ea-9e63-3dced7e80e8d.png)
As compared to a normal page on desktop: 
![image](https://user-images.githubusercontent.com/19171465/80729466-4f856c80-8ad6-11ea-810e-102440affe82.png)

New homepage design on mobile: 
<img src="https://user-images.githubusercontent.com/19171465/80729622-83609200-8ad6-11ea-9a4d-a71de9bf052a.png " width="350px"/>

On tablet: 
<img src="https://user-images.githubusercontent.com/19171465/80729685-9c694300-8ad6-11ea-835e-20581c1fba26.png" width="450px"/>

Pair programmed with @zebateira


