### PR TITLE
ON HOLD: Update redirect URL for go-filecoin-tutorial

### DIFF
--- a/docs/.vuepress/public/_redirects
+++ b/docs/.vuepress/public/_redirects
@@ -1,7 +1,6 @@
 # all redirects use 301 unless otherwise specified
 
-# redirect folks who try to visit docs.filecoin.io/go-filecoin/tutorial
-# since we're replacing the contents of docs.filecoin.io
-# TODO: fix the destination url (before :splat) when we pick a new location
+# redirect folks who try to visit the go tutorial at its old location,
+# docs.filecoin.io/go-filecoin/tutorial
 
 /go-filecoin-tutorial/*  https://go.filecoin.io/:splat

--- a/docs/.vuepress/public/_redirects
+++ b/docs/.vuepress/public/_redirects
@@ -4,4 +4,4 @@
 # since we're replacing the contents of docs.filecoin.io
 # TODO: fix the destination url (before :splat) when we pick a new location
 
-/go-filecoin-tutorial/*  https://docs.filecoin.io/go-filecoin-tutorial/:splat
+/go-filecoin-tutorial/*  https://go.filecoin.io/:splat

--- a/docs/.vuepress/public/_redirects
+++ b/docs/.vuepress/public/_redirects
@@ -3,4 +3,4 @@
 # redirect folks who try to visit the go tutorial at its old location,
 # docs.filecoin.io/go-filecoin/tutorial
 
-/go-filecoin-tutorial/*  https://go.filecoin.io/:splat
+/go-filecoin-tutorial/*  https://go.filecoin.io/go-filecoin-tutorial/:splat


### PR DESCRIPTION
HOLD to merge once the go-filecoin-tutorial is hosted at go.filecoin.io. 