### PR TITLE
Add IPFS & Filecoin page

### DIFF
--- a/docs/.vuepress/theme/components/Home.vue
+++ b/docs/.vuepress/theme/components/Home.vue
@@ -50,6 +50,10 @@ export default {
               path: '/introduction/why-filecoin'
             },
             {
+              title: 'IPFS and Filecoin',
+              path: '/introduction/ipfs-and-filecoin'
+            },
+            {
               title: 'Filecoin compared to...',
               path: '/introduction/filecoin-compared-to'
             }


### PR DESCRIPTION
Adds the IPFS and FIlecoin page to the introduction square on the lander