### PR TITLE
Add devnet connection instructions 

### DIFF
--- a/docs/how-to/build-interacting-with-the-network.md
+++ b/docs/how-to/build-interacting-with-the-network.md
@@ -24,7 +24,7 @@ Here are some scripts to set up your own remote networks for development:
 - [Lotus Docker Image](https://github.com/openworklabs/filecoin-docker) for a simple Lotus node Docker container
 - [Filecoin Chart](https://github.com/openworklabs/filecoin-chart) for more complex Lotus node architectures managed with Kubernetes
 
-## Developer network
+## Devnet
 In order to make testing easier, a live devnet (developer network) is now available for use. It features 512MB sectors and reduced proofs parameters, so sealing is much faster than in the full Testnet version.
 
 To connect to the Devnet:

--- a/docs/how-to/build-interacting-with-the-network.md
+++ b/docs/how-to/build-interacting-with-the-network.md
@@ -27,7 +27,7 @@ Here are some scripts to set up your own remote networks for development:
 ## Developer network
 In order to make testing easier, a live devnet (developer network) is now available for use. It features 512MB sectors and reduced proofs parameters, so sealing is much faster than in the full Testnet version.
 
-In order to set up the developer network:
+To connect to the Devnet:
 
 1. Delete any existing local Lotus repository, if one is present.
 2. Build and run Lotus from the `interop.6.1` tag. This should automatically connect you to the proper bootstrappers.

--- a/docs/how-to/build-interacting-with-the-network.md
+++ b/docs/how-to/build-interacting-with-the-network.md
@@ -25,7 +25,7 @@ Here are some scripts to set up your own remote networks for development:
 - [Filecoin Chart](https://github.com/openworklabs/filecoin-chart) for more complex Lotus node architectures managed with Kubernetes
 
 ## Developer network
-In order to speed up seal times and make testing easier, a live developer network is now available for use. It features 512MB sectors, which seal much faster than in the full Testnet version.
+In order to make testing easier, a live devnet (developer network) is now available for use. It features 512MB sectors and reduced proofs parameters, so sealing is much faster than in the full Testnet version.
 
 In order to set up the developer network:
 

--- a/docs/how-to/build-interacting-with-the-network.md
+++ b/docs/how-to/build-interacting-with-the-network.md
@@ -24,6 +24,17 @@ Here are some scripts to set up your own remote networks for development:
 - [Lotus Docker Image](https://github.com/openworklabs/filecoin-docker) for a simple Lotus node Docker container
 - [Filecoin Chart](https://github.com/openworklabs/filecoin-chart) for more complex Lotus node architectures managed with Kubernetes
 
+## Developer network
+In order to speed up seal times and make testing easier, a live developer network is now available for use. It features 512MB sectors, which seal much faster than in the full Testnet version.
+
+In order to set up the developer network:
+
+1. Delete any existing local Lotus repository, if one is present.
+2. Build and run Lotus from the `interop.6.1` tag. This should automatically connect you to the proper bootstrappers.
+3. Once running, several miners are configured to auto-accept any proposed deals. A complete list is currently in the works, but miners `t01725`, `t01473` and `t01608` are a few to get you started.
+
+ > **NOTICE:** At the moment, there are no guarantees on uptime for any of the auto-accepting miners. If one has gone offline or become unresponsive, please let us know in the Filecoin Slack.
+ 
 ## Testnet
 
 [Filecoin Testnet](https://filecoin.io/testnet/) is a live community test network, under active development.


### PR DESCRIPTION
(Ref. #79)

This PR adds a new section on the  "Interacting with the Network" page for setting up the new live devnet, and provides some miners for users to initially choose from.