### PR TITLE
Update Oxford comma description

### DIFF
--- a/docs/community/contribute/grammar-formatting-and-style.md
+++ b/docs/community/contribute/grammar-formatting-and-style.md
@@ -21,7 +21,7 @@ While Filecoin is a global project, the fact is that American English is the mos
 
 ### The Oxford comma
 
-Follow each list of three or more items with a comma `,`:
+In a list of three or more items, follow each item except the last with a comma `,`:
 
 | Use                           | Don't use                    |
 | ----------------------------- | ---------------------------- |


### PR DESCRIPTION
The existing description said to follow each list with a comma, when it should really be each item in the list, except for the last item.