### PR TITLE
Add instructions for featuring items on homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ To spin up a local instance of this new VuePress site, see below:
 ## Code organization
 - Content lives in Markdown files in the `docs` folder. Each major section has its own subfolder.
 - Navigation is generated from [docs/.vuepress/config.js](https://github.com/filecoin-project/filecoin-docs/blob/master/docs/.vuepress/config.js) and the metadata within each Markdown file. Be sure to create an entry in this config file when adding new content.
+- To feature a new article on the homepage, you'll also need to update the `manualSidebar` object in the Home component at [docs/.vuepress/themes/components/Home.vue](https://github.com/filecoin-project/filecoin-docs/blob/master/docs/.vuepress/theme/components/Home.vue).
 
 ## Contributing
 Learn more about [contributing to this docs site](https://docs.filecoin.io/community/contribute/ways-to-contribute/#documentation). 


### PR DESCRIPTION
Noticed many new contributors, so calling out that config.js does not automatically populate the homepage.