### PR TITLE
fix: internal links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,9 +3,10 @@
 ## Contributing to this documentation site
 
 For guidelines on contributing to the [Filecoin Docs](https://github.com/filecoin-project/filecoin-docs) repository, please explore our documentation:
-- [Contribution tutorial](./docs/community/contribute/contribution-tutorial)
-- [Writing guide](./docs/community/contribute/writing-guide)
-- [Grammar, formatting, and style](./docs/community/contribute/grammar-formatting-and-style)
+
+- [Contribution tutorial](./docs/community/contribute/contribution-tutorial.md)
+- [Writing guide](./docs/community/contribute/writing-guide.md)
+- [Grammar, formatting, and style](./docs/community/contribute/grammar-formatting-and-style.md)
 
 These guides are only concerned with documentation within this repository and does not contain any information regarding changes to VuePress or the HTML of the site. It also includes some general tips, tools, and workflows for creating helpful docs.
 
@@ -13,4 +14,4 @@ To learn how to host our VuePress site locally, see [README file](./README.md).
 
 ## Contributing to the Filecoin community
 
-Looking for other ways to get involved? Read about the many [ways to contribute](./docs/community/contribute/ways-to-contribute) to the Filecoin community.
+Looking for other ways to get involved? Read about the many [ways to contribute](./docs/community/contribute/ways-to-contribute.md) to the Filecoin community.

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,5 +12,5 @@ Available storage and pricing is not controlled by any single company. Instead, 
 
 There are many ways to participate in the Filecoin network, and several libraries, tools, products, and services to choose from:
 
-- If you're new to web3 and Filecoin, we recommend checking out the resources in [this guide](/introduction/new-to-web3).
-- If you're a developer looking to get started building on Filecoin, check out the [Build section](/build/).
+- If you're new to web3 and Filecoin, we recommend checking out the resources in [this guide](/introduction/new-to-web3.md).
+- If you're a developer looking to get started building on Filecoin, check out the [Build section](./build/README.md).

--- a/docs/build/README.md
+++ b/docs/build/README.md
@@ -9,24 +9,24 @@ Filecoin is for the builders. If you are excited about the potential of leveragi
 
 Read the resources in the **Start Building** section before you begin for helpful pointers on application architecture and networks to use when interacting and testing with Filecoin.
 
-- [Interacting with the network](./start-building/interacting-with-the-network/)
+- [Interacting with the network](./start-building/interacting-with-the-network.md)
 
 **Core Products** gives you an overview of the three main categories of products that we recommend to developers, and high-level pointers on how to run and integrate them in your application.
 
-- **For most developers**, we recommend getting started with [Filecoin-backed IPFS Pinning Services](./core-products/filecoin-backed-pinning-services). This is especially true if you’re coming to Filecoin from IPFS or other web3 ecosystems.
-- **For some developers who want to manage their own nodes**, we recommend using [Powergate](./core-products/powergate).
-- **For very advanced, protocol-level developers**, we recommend using [Filecoin protocol implementations](./core-products/protocol-implementations), e.g. [lotus](https://lotu.sh).
+- **For most developers**, we recommend getting started with [Filecoin-backed IPFS Pinning Services](./core-products/filecoin-backed-pinning-services.md). This is especially true if you’re coming to Filecoin from IPFS or other web3 ecosystems.
+- **For some developers who want to manage their own nodes**, we recommend using [Powergate](./core-products/powergate.md).
+- **For very advanced, protocol-level developers**, we recommend using [Filecoin protocol implementations](./core-products/protocol-implementations.md), e.g. [lotus](https://lotu.sh).
 
 **Developer Tools** provides brief descriptions and links to tools and libraries that provide important functionality for application developers.
 
-- [Wallets, signing tools, and API clients](./developer-tools/wallets-signing-tools-api-clients/) and [Filecoin Community Resources](https://github.com/filecoin-project/docs/wiki#community-resources) will direct you to various resources you can use in your applications
+- [Wallets, signing tools, and API clients](./developer-tools/wallets-signing-tools-api-clients.md) and [Filecoin Community Resources](https://github.com/filecoin-project/docs/wiki#community-resources) will direct you to various resources you can use in your applications
 - The Filecoin [Component Design System](http://filecoin.onrender.com/) is a design system that includes Filecoin-branded web UI components and tutorials that you can integrate into your application.
 
 **Examples** includes end-to-end code examples, tutorials, and walkthroughs for applications built on Filecoin. The examples section currently features:
 
-- [Meme Marketplace](./examples/meme-marketplace/overview/): An example application built on Textile Hub, a Filecoin-backed IPFS Pinning Service.
-- [Simple Pinning Service](./examples/simple-pinning-service/overview/): An example application built on Powergate.
-- [Slate](./examples/slate/overview/): A production application built on Powergate.
-- [Network Inspector](./examples/network-inspector/overview/): An example application built on lotus.
+- [Meme Marketplace](./examples/meme-marketplace/overview.md): An example application built on Textile Hub, a Filecoin-backed IPFS Pinning Service.
+- [Simple Pinning Service](./examples/simple-pinning-service/overview.md): An example application built on Powergate.
+- [Slate](./examples/slate/overview.md): A production application built on Powergate.
+- [Network Inspector](./examples/network-inspector/overview.md): An example application built on lotus.
 
 Please suggest any additional content that you would find useful using the links below.

--- a/docs/build/core-products/filecoin-backed-pinning-services.md
+++ b/docs/build/core-products/filecoin-backed-pinning-services.md
@@ -37,7 +37,7 @@ While each FPS provider will have slightly different instructions for utilizing 
 This section will be updated with documentation links for additional FPS providers as they come online.
 
 ::: tip
-See a walkthrough of an end-to-end example application (the Meme Marketplace) built on Textile Buckets [here](../examples/meme-marketplace/overview/).
+See a walkthrough of an end-to-end example application (the Meme Marketplace) built on Textile Buckets [here](../examples/meme-marketplace/overview.md).
 :::
 
 ## How FPS solutions work

--- a/docs/build/core-products/powergate.md
+++ b/docs/build/core-products/powergate.md
@@ -18,9 +18,9 @@ From the [Textile docs](https://docs.textile.io/powergate/):
 > - Easily configure, connect, and deploy Powergate, [Lotus](https://lotu.sh), and [IPFS](https://ipfs.io) together.
 > - Much more!
 
-**_Powergate is the recommended solution for developers who want an easier interface and better performance from Filecoin, but who prefer to manage their own nodes._** For most developers, we recommend using an [FPS](./filecoin-backed-pinning-services). For very low-level or advanced developers, you can integrate [lotus](https://lotu.sh) directly into your application.
+**_Powergate is the recommended solution for developers who want an easier interface and better performance from Filecoin, but who prefer to manage their own nodes._** For most developers, we recommend using an [FPS](./filecoin-backed-pinning-services.md). For very low-level or advanced developers, you can integrate [lotus](https://lotu.sh) directly into your application.
 
-The Powergate project is built and maintained by Textile. You can see the full Powergate docs [here](https://docs.textile.io/powergate/).
+The Powergate project is built and maintained by Textile. You can see the full [Powergate docs](https://docs.textile.io/powergate/).
 
 ## How to use Powergate
 
@@ -33,8 +33,8 @@ There are many ways to interact with the Powergate. These pathways are well-docu
 ::: tip
 Sometimes the best way to learn is through examples.
 
-- See a walkthrough of an example application (the Simple Pinning Service) built on the Powergate JS Client [here](../examples/simple-pinning-service/overview).
-- See a full production application (Slate) built on the Powergate JS Client [here](https://github.com/filecoin-project/slate/).
+- See a walkthrough of an example application (the Simple Pinning Service) built on the [Powergate JS Client](../examples/simple-pinning-service/overview.md).
+- See a full production application (Slate) built on the [Powergate JS Client](https://github.com/filecoin-project/slate/).
   :::
 
 ## How Powergate works

--- a/docs/build/core-products/protocol-implementations.md
+++ b/docs/build/core-products/protocol-implementations.md
@@ -29,11 +29,11 @@ Here is a snapshot of each implementation’s progress across the primary parts 
 
 ✅ : fully featured implementation | 🔄 : reuses components from another implementation | 🔶 : partial implementation
 
-**_We recommend that developers only build directly on Filecoin protocol implementations if they are very advanced developers or need to build at a very low level of the stack._** Filecoin protocol implementations expose low-level APIs that developers can use to integrate Filecoin directly into their applications. These APIs and their underlying functionality are still under heavy, active development, and require familiarity with blockchains and the Filecoin protocol. For most applications, we recommend developers use [FPS](./filecoin-backed-pinning-services) or [Powergate](./powergate).
+**_We recommend that developers only build directly on Filecoin protocol implementations if they are very advanced developers or need to build at a very low level of the stack._** Filecoin protocol implementations expose low-level APIs that developers can use to integrate Filecoin directly into their applications. These APIs and their underlying functionality are still under heavy, active development, and require familiarity with blockchains and the Filecoin protocol. For most applications, we recommend developers use [FPS](./filecoin-backed-pinning-services.md) or [Powergate](./powergate.md).
 
 ## How to use protocol implementations
 
-Generally speaking, you can use a Filecoin protocol implementation as a “client” (user) or a “miner” (storage provider) _(see [What is Filecoin?](../../introduction/what-is-filecoin) for more)_. Most implementations separate out the storage miner functionality into a separate process from the core node functionality. The core node runs the blockchain system, makes storage and retrieval deals, performs data transfers, supports block producer logic, and syncs and validates the chain. The storage miner process produces sector commitments and _Proofs-of-Spacetime_ to prove they have been correctly storing storage client data, among other important functions. To be a Filecoin “client,” you need to run a full node. To be a Filecoin "miner," you must run a full node and the storage mining process.
+Generally speaking, you can use a Filecoin protocol implementation as a “client” (user) or a “miner” (storage provider) _(see [What is Filecoin?](../../introduction/what-is-filecoin.md) for more)_. Most implementations separate out the storage miner functionality into a separate process from the core node functionality. The core node runs the blockchain system, makes storage and retrieval deals, performs data transfers, supports block producer logic, and syncs and validates the chain. The storage miner process produces sector commitments and _Proofs-of-Spacetime_ to prove they have been correctly storing storage client data, among other important functions. To be a Filecoin “client,” you need to run a full node. To be a Filecoin "miner," you must run a full node and the storage mining process.
 
 Each protocol implementation can be run and integrated in a few different ways:
 
@@ -46,10 +46,10 @@ If interacting with the implementation’s RPC APIs, the general development pat
 - Run a Filecoin node locally (e.g. run lotus locally) and have the application make RPC API requests to the local node.
 - Run a Filecoin node remotely (e.g. in the cloud) and have the application make RPC API requests to the remote node.
 
-Filecoin protocol implementations provide access to core Filecoin protocol workflows, with very few abstractions of the core concepts. This can be very useful, as it allows flexibility and precision in interacting with Filecoin network functionality. However, integrating nodes directly can require greater familiarity with how Filecoin works. To learn more about the various workflows enabled by the core Filecoin protocol, check-out the [How-tos](../../how-to).
+Filecoin protocol implementations provide access to core Filecoin protocol workflows, with very few abstractions of the core concepts. This can be very useful, as it allows flexibility and precision in interacting with Filecoin network functionality. However, integrating nodes directly can require greater familiarity with how Filecoin works. To learn more about the various workflows enabled by the core Filecoin protocol, check-out the [How-tos](../../how-to/README.md).
 
 ::: tip
-See a walkthrough of an end-to-end example application (the Filecoin Network Inspector) built using [Lotus’ JS API client](../examples/network-inspector/overview).
+See a walkthrough of an end-to-end example application (the Filecoin Network Inspector) built using [Lotus’ JS API client](../examples/network-inspector/overview.md).
 :::
 
 ## Resources

--- a/docs/build/examples/meme-marketplace/overview.md
+++ b/docs/build/examples/meme-marketplace/overview.md
@@ -5,7 +5,7 @@ description: A brief description of the Meme Marketplace Example.
 
 # Overview
 
-In this tutorial, we will build a meme marketplace using [Textile Hub](https://docs.textile.io/hub/), which is a [Filecoin-backed IPFS Pinning Service](../../core-products/filecoin-backed-pinning-services), and Ethereum ERC 721 standard.
+In this tutorial, we will build a meme marketplace using [Textile Hub](https://docs.textile.io/hub/), which is a [Filecoin-backed IPFS Pinning Service](../../core-products/filecoin-backed-pinning-services.md), and Ethereum ERC 721 standard.
 
 You will be able to upload memes to Textile Hub using a dashboard and register the memes with ERC 721 Non-fungible tokens, which will help anyone to uniquely identify the memes and their owners in a decentralized way!
 

--- a/docs/build/examples/sample-architectures.md
+++ b/docs/build/examples/sample-architectures.md
@@ -8,7 +8,7 @@ description: Learn how you might build an app on top of Filecoin.
 No matter what you wish to build on Filecoin, you'll generally need a few basic elements:
 
 - **A node.** Each Filecoin-based service or application will need to use at least one Filecoin node that maintains consensus. All interactions with the network must flow through an up-to-date node: sending and receiving market deals, sending and receiving data, and more. You can host this yourself, or choose a [hosted node](../start-building/interacting-with-the-network.md) option.
-- **An API.** Depending on language, and your preference for more granular or high-level commands, you can either directly use the node's go RPC API, or use one of the available [JS API client libraries](../developer-tools/wallets-signing-tools-api-clients.md#api-clients.md).
+- **An API.** Depending on language, and your preference for more granular or high-level commands, you can either directly use the node's go RPC API, or use one of the available [JS API client libraries](../developer-tools/wallets-signing-tools-api-clients.md#api-clients).
 - Optional: Additional helper tools and libraries to simplify functions such as storage commands, managing deals, and more.
 
 ### Examples

--- a/docs/build/examples/sample-architectures.md
+++ b/docs/build/examples/sample-architectures.md
@@ -7,8 +7,8 @@ description: Learn how you might build an app on top of Filecoin.
 
 No matter what you wish to build on Filecoin, you'll generally need a few basic elements:
 
-- **A node.** Each Filecoin-based service or application will need to use at least one Filecoin node that maintains consensus. All interactions with the network must flow through an up-to-date node: sending and receiving market deals, sending and receiving data, and more. You can host this yourself, or choose a [hosted node](../start-building/interacting-with-the-network/) option.
-- **An API.** Depending on language, and your preference for more granular or high-level commands, you can either directly use the node's go RPC API, or use one of the available [JS API client libraries](../developer-tools/wallets-signing-tools-api-clients/#api-clients).
+- **A node.** Each Filecoin-based service or application will need to use at least one Filecoin node that maintains consensus. All interactions with the network must flow through an up-to-date node: sending and receiving market deals, sending and receiving data, and more. You can host this yourself, or choose a [hosted node](../start-building/interacting-with-the-network.md) option.
+- **An API.** Depending on language, and your preference for more granular or high-level commands, you can either directly use the node's go RPC API, or use one of the available [JS API client libraries](../developer-tools/wallets-signing-tools-api-clients.md#api-clients.md).
 - Optional: Additional helper tools and libraries to simplify functions such as storage commands, managing deals, and more.
 
 ### Examples

--- a/docs/build/examples/simple-pinning-service/overview.md
+++ b/docs/build/examples/simple-pinning-service/overview.md
@@ -5,7 +5,7 @@ description: A brief description of the Simple Pinning Service Example.
 
 # Overview
 
-In this tutorial, we will build a simple pinning service using [Powergate](../../core-products/powergate).
+In this tutorial, we will build a simple pinning service using [Powergate](../../core-products/powergate.md).
 
 A pinning service is a remote service that helps you manage your data (like a decentralized Google Drive). In this tutorial's context, the data will be managed on Filecoin & IPFS.
 

--- a/docs/community/README.md
+++ b/docs/community/README.md
@@ -9,7 +9,7 @@ Filecoin is home to a vibrant, diverse community of thousands of contributors an
 
 ## Ways to contribute
 
-No matter your area of specialty or level of expertise, there are many [ways to contribute](./contribute/ways-to-contribute/) to Filecoin and make a real difference in the Filecoin community at large.
+No matter your area of specialty or level of expertise, there are many [ways to contribute](./contribute/ways-to-contribute.md) to Filecoin and make a real difference in the Filecoin community at large.
 
 ## Filecoin forums
 
@@ -25,4 +25,4 @@ ProtoSchool isn't just home to interactive tutorials on DWeb topics — it's als
 
 ## Social media
 
-We're in a lot of places. Here's [how to find them all](social-media/social-media) for your favorite platforms.
+We're in a lot of places. Here's [how to find them all](social-media/social-media.md) for your favorite platforms.

--- a/docs/community/contribute/contribution-tutorial.md
+++ b/docs/community/contribute/contribution-tutorial.md
@@ -5,7 +5,7 @@ description: Contribute to Filecoin documentation by finding issues, fixing them
 
 # Contribution tutorial
 
-While the [grammar, formatting, and style](./grammar-formatting-and-style) and the [writing guide](./writing-guide) can both help you write excellent content for the Filecoin Docs project, they don't delve into how you can actually submit you content changes. This guide will walk you through finding an issue, fixing it, and then submitting your fix to the `filecoin-project/filecoin-docs` project.
+While the [grammar, formatting, and style](./grammar-formatting-and-style.md) and the [writing guide](./writing-guide.md) can both help you write excellent content for the Filecoin Docs project, they don't delve into how you can actually submit you content changes. This guide will walk you through finding an issue, fixing it, and then submitting your fix to the `filecoin-project/filecoin-docs` project.
 
 There are plenty of small-sized issues around Filecoin documentation that make for easy, helpful contributions to the Filecoin project. Here, we'll walk through:
 

--- a/docs/community/contribute/grammar-formatting-and-style.md
+++ b/docs/community/contribute/grammar-formatting-and-style.md
@@ -5,7 +5,7 @@ description: Learn the syntax and formatting rules for writing documentation for
 
 # Grammar, formatting, and style
 
-This page details the syntax and formatting rules for writing Filecoin documentation. For more conceptual ideas of writing, check out the [writing guide](./writing-guide).
+This page details the syntax and formatting rules for writing Filecoin documentation. For more conceptual ideas of writing, check out the [writing guide](./writing-guide.md).
 
 ## Grammar and spelling
 

--- a/docs/community/contribute/ways-to-contribute.md
+++ b/docs/community/contribute/ways-to-contribute.md
@@ -30,14 +30,14 @@ Filecoin is a huge project and undertaking, and with lots of code comes the need
 
 Before contributing to the Filecoin docs, please read these quick guides; they'll save you time and help keep the docs accurate and consistent!
 
-1. [Style and formatting guide](./grammar-formatting-and-style)
-2. [Writing guide](./writing-guide)
+1. [Style and formatting guide](./grammar-formatting-and-style.md)
+2. [Writing guide](./writing-guide.md)
 
-If you have never contributed to an open-source project before, or just need a refresher, take a look at the [contribution tutorial](./contribution-tutorial).
+If you have never contributed to an open-source project before, or just need a refresher, take a look at the [contribution tutorial](./contribution-tutorial.md).
 
 ### Community
 
-If interacting with people is your favorite thing to do in this world, join the [Filecoin chat and discussion forums](../chat-and-discussion-forums) to say hello, meet others who share your goals, and connect with other members of the community.
+If interacting with people is your favorite thing to do in this world, join the [Filecoin chat and discussion forums](../chat-and-discussion-forums.md) to say hello, meet others who share your goals, and connect with other members of the community.
 
 ### Build Applications
 

--- a/docs/community/contribute/writing-guide.md
+++ b/docs/community/contribute/writing-guide.md
@@ -5,7 +5,7 @@ description: Learn the specifics of how to write documentation for the Filecoin 
 
 # Writing guide
 
-This guide explains how to write an article. While the [grammar, formatting, and style guide](./grammar-formatting-and-style) lets you know the rules you should follow, this guide will help you to properly structure your writing and choose the correct tone for your audience.
+This guide explains how to write an article. While the [grammar, formatting, and style guide](./grammar-formatting-and-style.md) lets you know the rules you should follow, this guide will help you to properly structure your writing and choose the correct tone for your audience.
 
 ## Walkthroughs
 

--- a/docs/how-to/README.md
+++ b/docs/how-to/README.md
@@ -13,4 +13,4 @@ Want to find even more resources for learning about Filecoin and the technologie
 
 ## Don't see what you're looking for?
 
-We're adding more documentation all the time and making ongoing revisions to existing docs, but if you don't see what you need, please [file an issue](https://github.com/filecoin-project/filecoin-docs/issues/new/choose) to let us know! We also recommend visiting the [Filecoin chat](/community/#community-chat) for support and discussion with Filecoin enthusiasts and experts worldwide.
+We're adding more documentation all the time and making ongoing revisions to existing docs, but if you don't see what you need, please [file an issue](https://github.com/filecoin-project/filecoin-docs/issues/new/choose) to let us know! We also recommend visiting the [Filecoin chat](../community/README.md#community-chat.md) for support and discussion with Filecoin enthusiasts and experts worldwide.

--- a/docs/how-to/README.md
+++ b/docs/how-to/README.md
@@ -13,4 +13,4 @@ Want to find even more resources for learning about Filecoin and the technologie
 
 ## Don't see what you're looking for?
 
-We're adding more documentation all the time and making ongoing revisions to existing docs, but if you don't see what you need, please [file an issue](https://github.com/filecoin-project/filecoin-docs/issues/new/choose) to let us know! We also recommend visiting the [Filecoin chat](../community/README.md#community-chat.md) for support and discussion with Filecoin enthusiasts and experts worldwide.
+We're adding more documentation all the time and making ongoing revisions to existing docs, but if you don't see what you need, please [file an issue](https://github.com/filecoin-project/filecoin-docs/issues/new/choose) to let us know! We also recommend visiting the [Filecoin chat](../community/README.md#community-chat) for support and discussion with Filecoin enthusiasts and experts worldwide.

--- a/docs/how-to/install-filecoin.md
+++ b/docs/how-to/install-filecoin.md
@@ -8,7 +8,7 @@ description: Learn how to get started with Filecoin.
 
 To install and run a Filecoin protocol implementation from the command-line, we recommend you install [lotus](https://github.com/filecoin-project/lotus), a Filecoin protocol implementation in Go. You can find installation instructions on the [lotus documentation site](https://lotu.sh/en+getting-started).
 
-For more ways to install and use Filecoin, check out the [Build section](../build/).
+For more ways to install and use Filecoin, check out the [Build section](../build/README.md).
 
 ### Before you begin:
 

--- a/docs/how-to/store/large-files.md
+++ b/docs/how-to/store/large-files.md
@@ -15,7 +15,7 @@ Filecoin can store any file format, but for very large files we recommend using 
 
 ### Maximizing storage
 
-The [simple recommendation](./prepare-data) is that files must be smaller than a sector. Colloquially, we refer to sectors as 1MB, 32GB, etc. To fully maximize storage usage, chunks can be fractionally larger. This is due to a combination of quirks:
+The [simple recommendation](./prepare-data.md) is that files must be smaller than a sector. Colloquially, we refer to sectors as 1MB, 32GB, etc. To fully maximize storage usage, chunks can be fractionally larger. This is due to a combination of quirks:
 
 - **Binary size:** Filecoin uses base 2 (binary) sizes. A "1MB sector" is actually 1MiB, or 1,048,576 bytes not 1,000,000 bytes.
 - **Padding:** For every 256 bits, subtract 2 bits (used by the Proofs processes). The remainder, 254 bits, is the usable storage space.

--- a/docs/how-to/store/prepare-data.md
+++ b/docs/how-to/store/prepare-data.md
@@ -25,4 +25,4 @@ Block data structures must be serialized into flat string files before importing
 
 For simple operations, you can use the `split` or `zip` Unix commands. Or, choose a client application that handles data preparation for you, such as the [Starling Storage CLI & REST API](https://github.com/filecoin-project/starling).
 
-Note: See [Very Large Files](./large-files) if you plan to store files larger than 1TB.
+Note: See [Very Large Files](./large-files.md) if you plan to store files larger than 1TB.

--- a/docs/introduction/README.md
+++ b/docs/introduction/README.md
@@ -10,8 +10,8 @@ Filecoin’s mission is to create a decentralized, efficient, and robust foundat
 
 Read on to learn more about the Filecoin network:
 
-- [New to web3](new-to-web3/)
-- [What is Filecoin?](what-is-filecoin/)
-- [Why Filecoin?](why-filecoin/)
-- [IPFS and Filecoin](ipfs-and-filecoin/)
-- [Filecoin compared to...](filecoin-compared-to/)
+- [New to web3](new-to-web3.md)
+- [What is Filecoin?](what-is-filecoin.md)
+- [Why Filecoin?](why-filecoin.md)
+- [IPFS and Filecoin](ipfs-and-filecoin.md)
+- [Filecoin compared to...](filecoin-compared-to.md)

--- a/docs/introduction/new-to-web3.md
+++ b/docs/introduction/new-to-web3.md
@@ -34,7 +34,7 @@ We recommend getting started by perusing the following resources.
 ### Filecoin
 
 - [Introducing Filecoin, a decentralized storage network](https://www.youtube.com/watch?v=EClPAFPeXIQ)
-- [What is Filecoin?](/introduction/what-is-filecoin)
-- [Why Filecoin?](/introduction/why-filecoin)
+- [What is Filecoin?](./what-is-filecoin.md)
+- [Why Filecoin?](./why-filecoin.md)
 - [Filecoin primer](https://ipfs.io/ipfs/QmWimYyZHzChb35EYojGduWHBdhf9SD5NHqf8MjZ4n3Qrr/Filecoin-Primer.7-25.pdf)
 - [Building the Filecoin ecosystem](https://youtu.be/SXlTBvcqzz8)

--- a/docs/introduction/why-filecoin.md
+++ b/docs/introduction/why-filecoin.md
@@ -1,6 +1,6 @@
 ---
 title: Why Filecoin?
-description: Explore the features that make Filecoin a compelling system for storing files. 
+description: Explore the features that make Filecoin a compelling system for storing files.
 ---
 
 # Why Filecoin?
@@ -77,4 +77,4 @@ The code that runs both clients and storage providers is open source. Storage pr
 
 ### Active community
 
-Filecoin has an active community of contributors to answer questions and help newcomers get started. There is an open dialog between users, developers and storage providers. If you need help, you will likely be able to reach the person who designed or built the system in question. Reach out on [Filecoin’s chat and forums](/community/chat-and-discussion-forums).
+Filecoin has an active community of contributors to answer questions and help newcomers get started. There is an open dialog between users, developers and storage providers. If you need help, you will likely be able to reach the person who designed or built the system in question. Reach out on [Filecoin’s chat and forums](../community/chat-and-discussion-forums.md).

--- a/docs/project/README.md
+++ b/docs/project/README.md
@@ -17,7 +17,7 @@ Learn about the ongoing cryptography research and design efforts that underpin t
 
 ## Related projects
 
-Filecoin is a highly modular project that is itself made out of many different protocols and tools. Learn more about the [Filecoin-related projects](related-projects) supported by Protocol Labs.
+Filecoin is a highly modular project that is itself made out of many different protocols and tools. Learn more about the [Filecoin-related projects](related-projects.md) supported by Protocol Labs.
 
 ## Code of conduct
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -13,4 +13,4 @@ View the [technical specification](https://github.com/filecoin-project/specs) fo
 
 ## Implementations
 
-Read more about Filecoin's protocol implementations [here](../build/core-products/protocol-implementations).
+Read more about Filecoin's protocol implementations [here](../build/core-products/protocol-implementations.md).


### PR DESCRIPTION
This PR fixes routing issues for relative paths and sets up links correctly so you can navigate the documentation via the GitHub UI.

**Note for contributors**: It's recommended to [append the filename and extension](https://vuepress.vuejs.org/guide/markdown.html#internal-links) to all links to enable these to resolve correctly in both contexts.

related: #117