### PR TITLE
Rework how-to/store section.

### DIFF
--- a/docs/how-to/store/large-files.md
+++ b/docs/how-to/store/large-files.md
@@ -13,28 +13,11 @@ Filecoin can store any file format; but for very large files, it is recommended 
 
 [TODO: Example of real data indexed and pointers to the subset that can grab that specific data, to help ppl think about splitting data up better for their use cases and specific file formats.]
 
-## Maximizing storage
-
-The [simple recommendation]((/how-to/store-prepare-data)) is that files must be smaller than a sector. Colloquially, sectors are referred to as 1MB, 32GB, etc. To fully maximize storage usage, chunks can be fractionally larger. This is due to a combination of quirks:
-
-- **Binary size:** Filecoin uses base 2 (binary) sizes. A "1MB sector" is actually 1MiB, or 1,048,576 bytes not 1,000,000 bytes.
-- **Padding:** For every 256 bits, subtract 2 bits (used by the Proofs processes). The remainder, 254 bits, is the usable storage space.
-
-**Example:**
-A 1MiB sector is 1,048,576 bytes. Next, multiply that by 254/256. Result: a 1MiB sector can hold 1,040,384 bytes of stored data.
-
-| Sector Size | Simplified Max Filesize     | Absolute Max Filesize |
-| ----------- | --------------------------- | --------------------- |
-| 2KiB        | 2KB (2,000 bytes)           | 2,032 bytes           |
-| 8MiB        | 8MB (8,000,000 bytes)       | 8,323,072 bytes       |
-| 512MiB      | 512MB (512,000,000 bytes)   | 532,676,608 bytes     |
-| 32GiB       | 32GB (32,000,000,000 bytes) | 34,091,302,912 bytes  |
-
 ## Storage deals with offline data transfer
 
 Filecoin's offline data transfer feature is recommended for petabyte-scale datasets and larger. This allows users with very large datasets to complete the data transfer step offline (e.g. by shipping hard drives from the client to the storage miner), while the storage deal continues to work as intended on-chain.
 
-It is implemented via a flag on the storage deal command that tells the client not to transfer the data over the network, and provides a piece CID (a unique identifier describing the data) to the miner instead, which a miner must then match for the deal to go through. This gives the client node flexibility in how it can set up the deal — for example, passing miners a specific location on a hard drive for the data they can use to generate the piece CID. 
+It is implemented via a flag on the storage deal command that tells the client not to transfer the data over the network, and provides a piece CID (a unique identifier describing the data) to the miner instead, which a miner must then match for the deal to go through. This gives the client node flexibility in how it can set up the deal — for example, passing miners a specific location on a hard drive for the data they can use to generate the piece CID.
 
 ### Performing deals with an offline data transfer
 
@@ -43,19 +26,22 @@ This section outlines the steps required to perform a storage deal through an of
 #### Generate a unique piece CID
 
 1. Use the Lotus client to generate a CAR file of the input:
-    ```
-    lotus client generate-car <inputPath> <outputPath>.
-    ```
-    
+
+   ```
+   lotus client generate-car <inputPath> <outputPath>.
+   ```
+
 2. Use the Lotus client to generate the piece CID:
-    ```
-    lotus client commP <inputCarFilePath> <minerAddress>
-    ```
+   ```
+   lotus client commP <inputCarFilePath> <minerAddress>
+   ```
 
 #### Identify a suitable miner
-Currently, 
 
-####  Propose an offline deal
+Currently,
+
+#### Propose an offline deal
+
 Propose the offline deal with the miner:
 
 ```
@@ -63,13 +49,15 @@ lotus client deal --manual-piece-cid=CID --manual-piece-size=datasize <Data CID>
 ```
 
 #### Transfer the data to the miner offline
+
 This can be done several ways, such as shipping hard drives from the client to the storage miner.
 
 #### Finalizing: The miner's role
+
 The miner can import the data and deal manually with:
 
-```            
+```
 lotus-storage-miner deals import-data <dealCid> <filePath>
 ```
 
-Once the first Proof of Spacetime (PoSt) hits the chain, the storage deal is considered active. 
+Once the first Proof of Spacetime (PoSt) hits the chain, the storage deal is considered active.

--- a/docs/how-to/store/offline-deals.md
+++ b/docs/how-to/store/offline-deals.md
@@ -1,0 +1,3 @@
+# Offline Deals
+
+Work-in-progress. Do not merge.

--- a/docs/how-to/store/prepare-data.md
+++ b/docs/how-to/store/prepare-data.md
@@ -3,26 +3,51 @@ title: Preparing data
 description: Learn how to prepare data for storage.
 ---
 
-# Preparing data
+# Is this section for you?
 
-Depending on the size and structure of your data, you may need to make some formatting adjustments before storing it on Filecoin.
+Most likely you will use Filecoin as a part of a larger system (eg. [Textile Hub](https://docs.textile.io/hub/), [Starling](https://github.com/filecoin-project/starling), [Space Daemon](https://blog.fleek.co/posts/daemon-release)) that takes care of many details for you.
 
-### For files bigger than a sector
+If you would like to store data directly onto Filecoin using a Filecoin implementation such as [Lotus](https://lotu.sh/), you will need to understand some basic concepts and limits.
 
-When you store data on the Filecoin Network, each file must be smaller than a sector. If an individual file is larger, you’ll have to split it into multiple smaller files first.
+### Sector Sizes
 
-How big is a sector? The Filecoin network supports several sector sizes, and storage miners will specify which size(s) they’re offering so you can select the best option for you. Smaller sectors are faster, while larger sectors are more cost-effective. (Testnet supports 32GiB and 64GiB sectors as of July 12, 2020).
+When you store data directly on the Filecoin Network as part of a deal, the total amount of data be must fit within a single sector. If you need to store data that is larger than a single sector, you must split the data and store it in separate sectors using multiple deals.
+
+The simplest data source that Filecoin supports is a single file uploaded to a Filecoin node. Additionally, some Filecoin nodes can import data from sources on the network such as IPFS, referenced by a content identifier (CID). When storing content referenced by a CID, the combined amount of data must have a byte count which is smaller than the sector size.
+
+**How big is a sector?** The Filecoin network supports several sector sizes, and storage miners will specify which size(s) they’re offering so you can select the best option for you. Miners can seal and unseal smaller sectors in less time, while larger sectors allow miners to seal more data in a single operation.
+
+Miners will typically pack several different deals into a single sector if they will fit. Larger sectors give miners more flexibility in combining deals, but miners may also have to wait longer to find enough data before they seal the sector. If the data to seal is smaller than the sector, the sealing process will pad the sector with empty (wasted) data. Miners are required to store a copy of a sector until all the deals sealed within have expired. Once a sector is sealed, it is impossible to modify or add data to it. Losing or destroying a sector prematurely will incur a penalty for the miner.
+
+Testnet and Mainnet will only support 32GiB and 64GiB sectors. Smaller sector sizes are available to developers, which seal faster, but are not secure enough to use in the production network.
+
+Note that there is a small amount of overhead required by the proofs, so in practice, the maximum file size is slightly smaller than the physical sector size. There is also a minimum file size.
+
+| Sector Size       | Minimum File Size | Maximum File Size    | Overhead          |
+| ----------------- | ----------------- | -------------------- | ----------------- |
+| 2KiB (dev only)   | 128 bytes         | 2,032 bytes          | 16 bytes          |
+| 8MiB (dev only)   | 128 bytes         | 8,323,072 bytes      | 65,536 bytes      |
+| 512MiB (dev only) | 128 bytes         | 532,676,608 bytes    | 4,194,304 bytes   |
+| 32GiB             | 128 bytes         | 34,091,302,912 bytes | 268,435,456 bytes |
+| 64GiB             | 128 bytes         | 68,182,605,824 bytes | 536,870,912 bytes |
+
+**FIXME**: These aren't the real limits ... do some testing to determine actual limits.
+
+In the future, Filecoin may support additional proofs which may have different sector sizes.
+
+### For data larger than a sector
+
+If an individual file is larger, you’ll have to split it into multiple smaller files first. There are many ways to do this. Check out the [large files](./large-files) tutorial for a simple way to do this using standard Unix command line tools.
 
 ### For files within a directory
 
-Each storage deal is for a single file. To store many files within a directory structure in a single storage operation (also known as storage deal), first flatten them into .zip, .car, or another archive file format.
+Each storage deal is for a single file. To store many files within a directory structure in a single storage operation (also known as storage deal), first flatten them into .zip, .car, or another archive file format. You can also store files in IPFS and create a storage deal for the CID if all the data will fit into a single sector. Other systems which store their data on Filecoin (such as [Textile Buckets](https://docs.textile.io/buckets/)) may take care of this for you.
 
-### Flattening block and object data
+### IPLD and CAR files
 
-Block data structures must be serialized into flat string files before importing into Filecoin. For IPLD data, we recommend the [Content Addressible Archive (CAR) format](https://github.com/ipld/specs/blob/master/block-layer/content-addressable-archives.md).
+[IPLD](https://ipld.io/) is a data model for working with hash-linked data structures which is used natively by systems such as [IPFS](https://ipfs.io/) and Filecoin. IPLD data structures can be stored in binary files, known as CAR files ([Content Addressible Archive](https://github.com/ipld/specs/blob/master/block-layer/content-addressable-archives.md)) that can imported or exported from Filecoin, IPFS or other systems that support it. It is possible to sync data from IPFS into Filecoin directly over the network using a CID, and then retrieve it as a CAR file, or vice-versa.
 
-### Helpers and utilities
+### Offline Deals
 
-For simple operations, you can use the `split` or `zip` Unix commands. Or, choose a client application that handles data preparation for you, such as the [Starling Storage CLI & REST API](https://github.com/filecoin-project/starling).
-
-Note: See [Very Large Files](./large-files.md) if you plan to store files larger than 1TB.
+If you have huge amounts of data, sending it all to a Filecoin miner via the Internet may not be possible. Filecoin also supports "Offline Deals", where you
+can negotiate a deal, and then put the data on physical media such as hard drives and ship it to the miner. See [Offline Deals](./offline-deals.md) to learn more.

--- a/docs/how-to/store/prepare-data.md
+++ b/docs/how-to/store/prepare-data.md
@@ -5,7 +5,7 @@ description: Learn how to prepare data for storage.
 
 # Is this section for you?
 
-Most likely you will use Filecoin as a part of a larger system (eg. [Textile Hub](https://docs.textile.io/hub/), [Starling](https://github.com/filecoin-project/starling), [Space Daemon](https://blog.fleek.co/posts/daemon-release)) that takes care of many details for you.
+Most likely you will use Filecoin as a part of a larger system such as a [Filecoin-backed IPFS Pinning Service](../../build/core-products/filecoin-backed-pinning-services/) that takes care of many details for you.
 
 If you would like to store data directly onto Filecoin using a Filecoin implementation such as [Lotus](https://lotu.sh/), you will need to understand some basic concepts and limits.
 


### PR DESCRIPTION
I moved the information on sector sizes to the start of the
section and included more links.

I'm going to turn the "Large Files" page into a mini-tutorial
on how to split data.

I am planning to create a separate "offline deals" page, as
well as include some more IPLD/Dumbo Drop techniques in an
advanced techniques section somewhere.