### PR TITLE
Update link to ProtoSchool in Related Projects

### DIFF
--- a/docs/project/related-projects.md
+++ b/docs/project/related-projects.md
@@ -24,4 +24,4 @@ The Multiformats Project is a collection of protocols which aim to future-proof 
 
 ## ProtoSchool
 
-Interactive tutorials on decentralized web protocols, designed to introduce you to decentralized web concepts, protocols, and tools. Complete code challenges right in your web browser and track your progress as you go. Learn more at [https://proto.school/](https://proto.school/).
+Interactive tutorials on decentralized web protocols, designed to introduce you to decentralized web concepts, protocols, and tools. Complete code challenges right in your web browser and track your progress as you go. Explore ProtoSchool's tutorials on Filecoin at: [https://proto.school/](https://proto.school/#/tutorials?course=filecoin

--- a/docs/project/related-projects.md
+++ b/docs/project/related-projects.md
@@ -24,4 +24,4 @@ The Multiformats Project is a collection of protocols which aim to future-proof 
 
 ## ProtoSchool
 
-Interactive tutorials on decentralized web protocols, designed to introduce you to decentralized web concepts, protocols, and tools. Complete code challenges right in your web browser and track your progress as you go. Explore ProtoSchool's tutorials on Filecoin at: [https://proto.school/](https://proto.school/#/tutorials?course=filecoin
+Interactive tutorials on decentralized web protocols, designed to introduce you to decentralized web concepts, protocols, and tools. Complete code challenges right in your web browser and track your progress as you go. Explore ProtoSchool's tutorials on Filecoin at [https://proto.school/](https://proto.school/#/tutorials?course=filecoin).


### PR DESCRIPTION
Edit to link directly to a filtered list of Filecoin on content. I'm okay with matching the text to the real link but it gets pretty bulky so I've currently only displayed the URL for the main website while linking to the Filecoin course.