### PR TITLE
Add guidelines on Filecoin term usage to grammar/style guide

### DIFF
--- a/docs/community/contribute/grammar-formatting-and-style.md
+++ b/docs/community/contribute/grammar-formatting-and-style.md
@@ -45,14 +45,14 @@ The name can also be used as an adjective:
 
 > I love contributing to Filecoin documentation!
 
-When referring to the token used as Filecoin's currency, the unit symbol, `FIL`, is preferred; it is alternatively denoted by the Unicode symbol for an integral with a double stroke (⨎). These symbols can be used as suffixes or prefixes, as seen fit:
+When referring to the token used as Filecoin's currency, the name `FIL`, is preferred; it is alternatively denoted by the Unicode symbol for an integral with a double stroke (⨎). These symbols can be used as suffixes or prefixes, as seen fit:
 
-- Code prefix: **100 FIL**.
-- Code suffix: **FIL 100**.
+- Unit prefix: **100 FIL**.
+- Unit suffix: **FIL 100**.
 - Symbol prefix: **⨎100**.
 - Symbol suffix: **100 ⨎**.
 
-The singular form of the common noun "filecoin" is also sometimes used for this purpose - this form should not be used as an adjective.
+The smallest and most common denomination of FIL is the `attoFIL` (10^-18 FIL).
 
 > The collateral for this storage deal is five FIL.
 

--- a/docs/community/contribute/grammar-formatting-and-style.md
+++ b/docs/community/contribute/grammar-formatting-and-style.md
@@ -28,6 +28,40 @@ In a list of three or more items, follow each item except the last with a comma 
 | One, two, three, and four.    | One, two, three and four.    |
 | Henry, Elizabeth, and George. | Henry, Elizabeth and George. |
 
+
+### References to Filecoin
+
+As a proper noun, the name "Filecoin" (capitalized) should be used only to refer to the overarching project, to the protocol, or to the project's canonical network:
+
+> Filecoin [the project] has attracted contributors from around the globe!
+> Filecoin [the protocol] rewards contributions of data storage instead of computation!
+> Filecoin [the network] is currently storing 50 PiB of data!
+
+The name can also be used as an adjective: 
+
+> The Filecoin ecosystem is thriving!
+> I love contributing to Filecoin documentation!
+
+When referring to the token used as Filecoin's currency, the unit symbol, `FIL`, is preferred; it is alternatively denoted by the Unicode symbol for an integral with a double stroke (⨎). These symbols can be used as suffixes or prefixes, as seen fit:
+
+- Code prefix: **100 FIL**.
+- Code suffix: **FIL 100**.
+- Symbol prefix: **⨎100**.
+- Symbol suffix: **100 ⨎**.
+
+The singular form of the common noun "filecoin" is also sometimes used for this purpose - this form should not be used as an adjective.
+
+> The collateral for this storage deal is five FIL.
+> I generated ⨎100 as a storage miner last month! 
+> My wallet has thirty filecoin.
+
+Examples of discouraged usage:
+> Filecoin rewards miners with Filecoin.
+> There are many ways to participate in the filecoin community.
+> My wallet has thirty filecoins.
+
+Consistency in the usage of these terms helps keep these various concepts distinct.
+
 ### Acronyms
 
 If you have to use an acronym, spell the full phrase first and include the acronym in parentheses `()` the first time it is used in each document. Exception: This generally isn't necessary for commonly-encountered acronyms like _IPFS_, unless writing for a stand-alone article that may not be presented alongside project documentation.

--- a/docs/community/contribute/grammar-formatting-and-style.md
+++ b/docs/community/contribute/grammar-formatting-and-style.md
@@ -34,12 +34,15 @@ In a list of three or more items, follow each item except the last with a comma 
 As a proper noun, the name "Filecoin" (capitalized) should be used only to refer to the overarching project, to the protocol, or to the project's canonical network:
 
 > Filecoin [the project] has attracted contributors from around the globe!
+
 > Filecoin [the protocol] rewards contributions of data storage instead of computation!
+
 > Filecoin [the network] is currently storing 50 PiB of data!
 
 The name can also be used as an adjective: 
 
 > The Filecoin ecosystem is thriving!
+
 > I love contributing to Filecoin documentation!
 
 When referring to the token used as Filecoin's currency, the unit symbol, `FIL`, is preferred; it is alternatively denoted by the Unicode symbol for an integral with a double stroke (⨎). These symbols can be used as suffixes or prefixes, as seen fit:
@@ -52,12 +55,16 @@ When referring to the token used as Filecoin's currency, the unit symbol, `FIL`,
 The singular form of the common noun "filecoin" is also sometimes used for this purpose - this form should not be used as an adjective.
 
 > The collateral for this storage deal is five FIL.
+
 > I generated ⨎100 as a storage miner last month! 
+
 > My wallet has thirty filecoin.
 
 Examples of discouraged usage:
 > Filecoin rewards miners with Filecoin.
+
 > There are many ways to participate in the filecoin community.
+
 > My wallet has thirty filecoins.
 
 Consistency in the usage of these terms helps keep these various concepts distinct.

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -42,7 +42,7 @@ Time in the Filecoin blockchain is discretized into _epochs_ that are currently 
 
 ## FIL
 
-`FIL` is the unit symbol for the Filecoin currency; it is alternatively denoted by the Unicode symbol for an integral with a double stroke (⨎).
+_FIL_ is the name of the Filecoin unit of currency; it is alternatively denoted by the Unicode symbol for an integral with a double stroke (⨎).
 
 ## Faucet
 
@@ -54,7 +54,7 @@ When a [storage miner](#storage-miner) fails to complete [Window Proof-of-Spacet
 
 ## Filecoin
 
-The term _Filecoin_, in the sense of a proper noun, is used generically to refer to the Filecoin project, network, broader ecosystem, and community. As a common noun, the singular form, filecoin, is used to refer to the Filecoin currency.
+The term _Filecoin_ is used generically to refer to the Filecoin project, protocol, and network.
 
 ## Gas
 


### PR DESCRIPTION
Here's a draft that seeks to clarify the project's preferred usage of the terms "Filecoin", FIL, filecoin, etc. in the documentation for contributors. This addresses a small component of #215 