### PR TITLE
add troubleshooting table

### DIFF
--- a/docs/mine/connectivity.md
+++ b/docs/mine/connectivity.md
@@ -153,4 +153,9 @@ Connectivity issues? Please run the following steps:
 1. Go to [https://calibration.spacerace.filecoin.io/check](https://calibration.spacerace.filecoin.io/check) to check if the dealbot can successfully get a query-ask from your miner
 1. Check deal details page for your miner at [https://calibration.spacerace.filecoin.io/](https://calibration.spacerace.filecoin.io/). If it shows an error “routing: not found”, follow the steps in [Setting Multiaddresses](#setting-multiaddresses) to set your `lotus-miner actor set-addrs`.
 
+| Error | What it means | How to fix |
+|---|---|---|
+| Failed: failed to open stream to miner: routing: not found | This error means the dealbot was not able to... | fix | 
+| StorageDealError: error reading Response message: stream reset | This means a connection was initially made, but changed unexpectedly (disappeared, lost, unroutable, power failure, anything) during the storage deal process. | fix | 
+
 If you fail to succeed in any of these steps, please start a thread on #fil-net-calibration in the [Filecoin Slack](http://filecoin.io/slack). Please include all of the steps you have tried, their output, and your miner ID.

--- a/docs/mine/connectivity.md
+++ b/docs/mine/connectivity.md
@@ -155,7 +155,10 @@ Connectivity issues? Please run the following steps:
 
 | Error | What it means | How to fix |
 |---|---|---|
-| Failed: failed to open stream to miner: routing: not found | This error means the dealbot was not able to... | fix | 
-| StorageDealError: error reading Response message: stream reset | This means a connection was initially made, but changed unexpectedly (disappeared, lost, unroutable, power failure, anything) during the storage deal process. | fix | 
+| ClientQueryAsk failed : failed to open stream to miner: dial backoff | The connection to the remote host was attempted, but failed. | This may be due to issues with porting, IPs set within the config file, or simply no internet connectivity. |
+| ClientQueryAsk failed : failed to open stream to miner: failed to dial | The deal-bot was unable to open a network socket to the miner. | This is likely because the miner's IP is not publicly dialable, or a port issue. |
+| ClientQueryAsk failed : failed to open stream to miner: routing: not found | The deal-bot was unable to locate the miners IP and/or port. | Follow the instructions under the [multiaddresses section](#setting-multiaddresses) of this page. |
+| ClientQueryAsk failed : failed to read ask response: stream reset | Connectivity loss, usually due to a high packet droprate. | Check your internet connectivity and available bandwidth. |
+
 
 If you fail to succeed in any of these steps, please start a thread on #fil-net-calibration in the [Filecoin Slack](http://filecoin.io/slack). Please include all of the steps you have tried, their output, and your miner ID.


### PR DESCRIPTION
This PR aims to add a troubleshooting table with common error messages, explanations, and recommended fixes. @har00ga can you take this over and land it today?

Please also add these errors:

- ClientQueryAsk failed : failed to open stream to miner: dial backoff
- ClientQueryAsk failed : failed to open stream to miner: failed to dial
- ClientQueryAsk failed : failed to open stream to miner: routing: not found
- ClientQueryAsk failed : failed to read ask response: stream reset
- {"code":1,"message":"cannot make retrieval deal for zero bytes"}

@daviddias - If you could provide a head start on the info required here that would be super helpful.

If explanations or fix recos are still missing please chase it down in #fil-space-race-admin.