### PR TITLE
feat: add custom 404 page

### DIFF
--- a/docs/.vuepress/public/_redirects
+++ b/docs/.vuepress/public/_redirects
@@ -5,5 +5,5 @@
 /questions.html https://go.filecoin.io/questions.html
 /go-filecoin-tutorial/*  https://go.filecoin.io/go-filecoin-tutorial/:splat
 
-# SPA router redirects to catch 404s
-/* /index.html 200
+# use a custom 404 for any pages that are not rendered
+/* /404/index.html 404

--- a/docs/.vuepress/public/_redirects
+++ b/docs/.vuepress/public/_redirects
@@ -5,3 +5,5 @@
 /questions.html https://go.filecoin.io/questions.html
 /go-filecoin-tutorial/*  https://go.filecoin.io/go-filecoin-tutorial/:splat
 
+# SPA router redirects to catch 404s
+/* /index.html 200

--- a/docs/.vuepress/theme/layouts/404.vue
+++ b/docs/.vuepress/theme/layouts/404.vue
@@ -28,6 +28,12 @@ export default {
     Navbar
   },
 
+  created() {
+    if (typeof this.$ssrContext !== 'undefined') {
+      this.$ssrContext.userHeadTags += `<base href="/" />`
+    }
+  },
+
   mounted() {
     // bail if ga is not enabled
     if (!window.ga) return

--- a/docs/.vuepress/theme/layouts/404.vue
+++ b/docs/.vuepress/theme/layouts/404.vue
@@ -24,6 +24,17 @@ export default {
   components: {
     Navbar
   },
+
+  mounted() {
+    // bail if ga is not enabled
+    if (!window.ga) return
+
+    window.ga('send', 'event', {
+      eventCategory: '404',
+      eventAction: this.currentPath,
+      eventLabel: document.referrer
+    })
+  },
   methods: {
     searchFocus(e) {
       e.preventDefault()

--- a/docs/.vuepress/theme/layouts/404.vue
+++ b/docs/.vuepress/theme/layouts/404.vue
@@ -2,16 +2,19 @@
   <div class="theme-container">
     <Navbar />
     <div class="theme-default-content">
-      <h1>🤷‍♀️ 404</h1>
+      <h1>😯 404</h1>
+      <h3>Oops, this page has moved or no longer exists</h3>
 
-      <blockquote>
-        Oops, it seems that this page has moved or no longer exists.
-      </blockquote>
-
-      <RouterLink to="/">
-        Return home
-      </RouterLink>
-      or <a href="#" @click="searchFocus">try to search</a>.
+      <p>
+        We've logged this issue and invite you to choose your next adventure
+        below.
+      </p>
+      <p>
+        <RouterLink to="/">
+          Return home
+        </RouterLink>
+        or <a href="#" @click="searchFocus">try our superb search</a>
+      </p>
     </div>
   </div>
 </template>

--- a/docs/.vuepress/theme/layouts/404.vue
+++ b/docs/.vuepress/theme/layouts/404.vue
@@ -1,0 +1,34 @@
+<template>
+  <div class="theme-container">
+    <Navbar />
+    <div class="theme-default-content">
+      <h1>🤷‍♀️ 404</h1>
+
+      <blockquote>
+        Oops, it seems that this page has moved or no longer exists.
+      </blockquote>
+
+      <RouterLink to="/">
+        Return home
+      </RouterLink>
+      or <a href="#" @click="searchFocus">try to search</a>.
+    </div>
+  </div>
+</template>
+
+<script>
+import Navbar from '@theme/components/Navbar.vue'
+
+export default {
+  name: 'NotFound',
+  components: {
+    Navbar
+  },
+  methods: {
+    searchFocus(e) {
+      e.preventDefault()
+      document.querySelector('#search-form input').focus()
+    }
+  }
+}
+</script>

--- a/docs/.vuepress/theme/layouts/404.vue
+++ b/docs/.vuepress/theme/layouts/404.vue
@@ -34,7 +34,7 @@ export default {
 
     window.ga('send', 'event', {
       eventCategory: '404',
-      eventAction: this.currentPath,
+      eventAction: this.$route.path,
       eventLabel: document.referrer
     })
   },


### PR DESCRIPTION
This implements the first version of a custom 404 page, inviting the user to return home or try search to complete their request.

An event for the error is triggered so we can monitor inbound 404 issues and attempt to fix them with redirects or content updates.   

![2020-08-05 at 19 19 30](https://user-images.githubusercontent.com/106938/89449315-cc1c8c80-d750-11ea-95d6-c9ebc8c14834.gif)

fixes: #175 