### PR TITLE
Remove upnp section

### DIFF
--- a/docs/mine/connectivity.md
+++ b/docs/mine/connectivity.md
@@ -55,8 +55,6 @@ lotus-miner net connect <address1> <address2>…
 
 In order to ensure that Filecoin packets are able to pass freely and unfiltered through a local firewall, it is highly recommended to set up port forwarding for a miner's `libp2p` address. By default, this port is randomised; for optimal connectivity, make sure that it is set to a static IP. 
 
-#### Option 1: Standard port forwarding
-
 To enable port forwarding on your local router:
 
 1. Browse to the management website for your home router (typically http://192.168.1.1)
@@ -67,10 +65,6 @@ To enable port forwarding on your local router:
     * Internal port: [CHOSEN PORT]
     * Protocol: TCP
     * IP Address: Private IP address of the host system running the miner
-
-#### Option 2: UPnP setup
-
-Alternatively, users with routers that support universal plug and play (UPnP) can set up their firewalling automatically by configuring their client's daemon to use the address `0.0.0.0`. Note that, if using UPnP, **standard port forwarding does not need to be set up,** and can cause issues if used in parallel.  
 
 ## Establishing a public IP address
 


### PR DESCRIPTION
Due to the fact that the port number of the miner will be put on chain by the `set-addrs` call, it is ill-advised to use UPnP as it will potentially provide a new port if the process is restarted. This was my mistake as I suggested this change before I knew about putting the address on chain.