### PR TITLE
feat: documentation navigation refactor

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -81,7 +81,6 @@ module.exports = {
         nav: require('./nav/en'),
         sidebar: {
           '/mine/': [
-            '',
             '/mine/storage-mining',
             '/mine/lotus-seal-worker',
             '/mine/setting-a-static-port',

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -251,10 +251,7 @@ module.exports = {
                 },
                 getStoreSection()
               ]
-            },
-            ['/mine/', 'Mine'],
-            ['/build/', 'Build'],
-            ['/reference/', 'Reference']
+            }
           ]
         }
       }

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -124,13 +124,13 @@ module.exports = {
               title: 'Example Apps',
               sidebarDepth: 2,
               path: '/build/examples/sample-architectures/',
+              collapsable: false,
               children: [
                 'examples/sample-architectures',
                 ['examples/web-applications/overview', 'Web Applications'],
                 {
                   title: 'Simple Pinning Service',
                   path: '/build/examples/simple-pinning-service/overview/',
-                  collapsable: false,
                   children: [
                     '/build/examples/simple-pinning-service/powergate-lotus-go-ipfs-interactions',
                     '/build/examples/simple-pinning-service/step-1-powergate-setup',
@@ -144,7 +144,6 @@ module.exports = {
                 {
                   title: 'Network Inspector',
                   path: '/build/examples/network-inspector/overview/',
-                  collapsable: false,
                   children: [
                     '/build/examples/network-inspector/lotus-and-go-ipfs-interactions',
                     '/build/examples/network-inspector/step-1-start-lotus-devnet-and-go-ipfs',
@@ -158,7 +157,6 @@ module.exports = {
                 {
                   title: 'Meme Marketplace',
                   path: '/build/examples/meme-marketplace/overview/',
-                  collapsable: false,
                   children: [
                     '/build/examples/meme-marketplace/textile-hub-buckets-and-erc721',
                     '/build/examples/meme-marketplace/step-1-blockchain-and-contracts-setup',
@@ -175,9 +173,59 @@ module.exports = {
             }
           ],
           '/reference/': [
+            ['/', '<- Home'],
             'glossary',
             ['https://github.com/filecoin-project/specs', 'Specification'],
             ['https://lotu.sh/', 'Lotus tutorial']
+          ],
+          '/project/': [
+            {
+              title: 'Project',
+              path: '/project/',
+              collapsable: false,
+              children: [
+                [
+                  'https://app.instagantt.com/shared/s/1152992274307505/latest',
+                  'Roadmap'
+                ],
+                ['https://research.filecoin.io/', 'Research'],
+                '/project/related-projects',
+                [
+                  'https://github.com/filecoin-project/community/blob/master/CODE_OF_CONDUCT.md',
+                  'Code of conduct'
+                ]
+              ]
+            }
+          ],
+          '/community/': [
+            {
+              title: 'Community',
+              path: '/community/',
+              collapsable: false,
+              children: [
+                {
+                  title: 'Join the community',
+                  sidebarDepth: 2,
+                  collapsable: false,
+                  children: [
+                    '/community/contribute/ways-to-contribute',
+                    '/community/chat-and-discussion-forums',
+                    ['https://proto.school/#/events', 'ProtoSchool workshops'],
+                    '/community/social-media/social-media'
+                  ]
+                },
+                {
+                  title: 'Write the docs',
+                  sidebarDepth: 1,
+                  collapsable: false,
+                  children: [
+                    '/community/contribute/grammar-formatting-and-style',
+                    '/community/contribute/writing-guide',
+                    '/community/contribute/contribution-tutorial'
+                  ]
+                }
+              ]
+            }
           ],
           '/': [
             {
@@ -205,49 +253,9 @@ module.exports = {
                 getStoreSection()
               ]
             },
-            {
-              title: 'Community',
-              path: '/community/',
-              children: [
-                {
-                  title: 'Join the community',
-                  sidebarDepth: 2,
-                  collapsable: false,
-                  children: [
-                    '/community/contribute/ways-to-contribute',
-                    '/community/chat-and-discussion-forums',
-                    ['https://proto.school/#/events', 'ProtoSchool workshops'],
-                    '/community/social-media/social-media'
-                  ]
-                },
-                {
-                  title: 'Write the docs',
-                  sidebarDepth: 1,
-                  collapsable: false,
-                  children: [
-                    '/community/contribute/grammar-formatting-and-style',
-                    '/community/contribute/writing-guide',
-                    '/community/contribute/contribution-tutorial'
-                  ]
-                }
-              ]
-            },
-            {
-              title: 'Project',
-              path: '/project/',
-              children: [
-                [
-                  'https://app.instagantt.com/shared/s/1152992274307505/latest',
-                  'Roadmap'
-                ],
-                ['https://research.filecoin.io/', 'Research'],
-                '/project/related-projects',
-                [
-                  'https://github.com/filecoin-project/community/blob/master/CODE_OF_CONDUCT.md',
-                  'Code of conduct'
-                ]
-              ]
-            }
+            ['/mine/', 'Mine'],
+            ['/build/', 'Build'],
+            ['/reference/', 'Reference']
           ]
         }
       }

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -121,8 +121,7 @@ module.exports = {
               ]
             },
             {
-              title: 'Examples',
-              collapsable: false,
+              title: 'Example Apps',
               sidebarDepth: 2,
               path: '/build/examples/sample-architectures/',
               children: [

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -208,7 +208,6 @@ module.exports = {
             {
               title: 'Project',
               path: '/project/',
-              collapsable: false,
               children: [
                 [
                   'https://app.instagantt.com/shared/s/1152992274307505/latest',
@@ -226,7 +225,6 @@ module.exports = {
             {
               title: 'Community',
               path: '/community/',
-              collapsable: false,
               children: [
                 {
                   title: 'Join the community',

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -173,7 +173,6 @@ module.exports = {
             }
           ],
           '/reference/': [
-            ['/', '<- Home'],
             'glossary',
             ['https://github.com/filecoin-project/specs', 'Specification'],
             ['https://lotu.sh/', 'Lotus tutorial']

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -2,6 +2,19 @@
 
 const DEPLOY_DOMAIN = 'https://docs.filecoin.io'
 
+const getStoreSection = () => ({
+  title: 'Store Data',
+  collapsable: false,
+  path: '/how-to/store/prepare-data/',
+  children: [
+    '/how-to/store/prepare-data',
+    '/how-to/store/tokens',
+    '/how-to/store/making-storage-deals',
+    '/how-to/store/retrieving-data',
+    '/how-to/store/large-files'
+  ]
+})
+
 module.exports = {
   base: '/',
   head: require('./head'),
@@ -77,35 +90,27 @@ module.exports = {
             '/mine/mining-troubleshooting'
           ],
           '/build/': [
-            '',
             {
               title: 'Start Building',
               collapsable: false,
+              path: '/build/start-building/interacting-with-the-network/',
               children: ['start-building/interacting-with-the-network']
             },
             {
               title: 'Core Products',
               collapsable: false,
+              path: '/build/core-products/filecoin-backed-pinning-services/',
               children: [
                 'core-products/filecoin-backed-pinning-services',
                 'core-products/powergate',
                 'core-products/protocol-implementations'
               ]
             },
-            {
-              title: 'Store Data',
-              collapsable: false,
-              children: [
-                '/how-to/store/prepare-data',
-                '/how-to/store/tokens',
-                '/how-to/store/making-storage-deals',
-                '/how-to/store/retrieving-data',
-                '/how-to/store/large-files'
-              ]
-            },
+            getStoreSection(),
             {
               title: 'Developer Tools',
               collapsable: false,
+              path: '/build/developer-tools/wallets-signing-tools-api-clients/',
               children: [
                 'developer-tools/wallets-signing-tools-api-clients',
                 [
@@ -119,12 +124,13 @@ module.exports = {
               title: 'Examples',
               collapsable: false,
               sidebarDepth: 2,
+              path: '/build/examples/sample-architectures/',
               children: [
                 'examples/sample-architectures',
                 ['examples/web-applications/overview', 'Web Applications'],
                 {
                   title: 'Simple Pinning Service',
-                  path: '/build/examples/simple-pinning-service/overview',
+                  path: '/build/examples/simple-pinning-service/overview/',
                   collapsable: false,
                   children: [
                     '/build/examples/simple-pinning-service/powergate-lotus-go-ipfs-interactions',
@@ -138,7 +144,7 @@ module.exports = {
                 },
                 {
                   title: 'Network Inspector',
-                  path: '/build/examples/network-inspector/overview',
+                  path: '/build/examples/network-inspector/overview/',
                   collapsable: false,
                   children: [
                     '/build/examples/network-inspector/lotus-and-go-ipfs-interactions',
@@ -152,7 +158,7 @@ module.exports = {
                 },
                 {
                   title: 'Meme Marketplace',
-                  path: '/build/examples/meme-marketplace/overview',
+                  path: '/build/examples/meme-marketplace/overview/',
                   collapsable: false,
                   children: [
                     '/build/examples/meme-marketplace/textile-hub-buckets-and-erc721',
@@ -196,7 +202,8 @@ module.exports = {
                   sidebarDepth: 1,
                   collapsable: false,
                   children: ['/how-to/install-filecoin', '/how-to/networks']
-                }
+                },
+                getStoreSection()
               ]
             },
             {

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -177,7 +177,34 @@ module.exports = {
             ['https://github.com/filecoin-project/specs', 'Specification'],
             ['https://lotu.sh/', 'Lotus tutorial']
           ],
-          '/project/': [
+          '/': [
+            {
+              title: 'Introduction',
+              path: '/introduction/',
+              collapsable: false,
+              children: [
+                '/introduction/new-to-web3',
+                '/introduction/what-is-filecoin',
+                '/introduction/why-filecoin',
+                '/introduction/ipfs-and-filecoin',
+                '/introduction/filecoin-compared-to',
+                '/introduction/faq'
+              ]
+            },
+            {
+              title: 'How-tos',
+              path: '/how-to/',
+              collapsable: false,
+              children: [
+                {
+                  title: 'Install Filecoin',
+                  sidebarDepth: 1,
+                  collapsable: false,
+                  children: ['/how-to/install-filecoin', '/how-to/networks']
+                },
+                getStoreSection()
+              ]
+            },
             {
               title: 'Project',
               path: '/project/',
@@ -194,9 +221,8 @@ module.exports = {
                   'Code of conduct'
                 ]
               ]
-            }
-          ],
-          '/community/': [
+            },
+
             {
               title: 'Community',
               path: '/community/',
@@ -223,33 +249,6 @@ module.exports = {
                     '/community/contribute/contribution-tutorial'
                   ]
                 }
-              ]
-            }
-          ],
-          '/': [
-            {
-              title: 'Introduction',
-              path: '/introduction/',
-              children: [
-                '/introduction/new-to-web3',
-                '/introduction/what-is-filecoin',
-                '/introduction/why-filecoin',
-                '/introduction/ipfs-and-filecoin',
-                '/introduction/filecoin-compared-to',
-                '/introduction/faq'
-              ]
-            },
-            {
-              title: 'How-tos',
-              path: '/how-to/',
-              children: [
-                {
-                  title: 'Install Filecoin',
-                  sidebarDepth: 1,
-                  collapsable: false,
-                  children: ['/how-to/install-filecoin', '/how-to/networks']
-                },
-                getStoreSection()
               ]
             }
           ]

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -66,205 +66,190 @@ module.exports = {
           }
         },
         nav: require('./nav/en'),
-        sidebar: [
-          {
-            title: 'Introduction',
-            path: '/introduction/',
-            children: [
-              '/introduction/new-to-web3',
-              '/introduction/what-is-filecoin',
-              '/introduction/why-filecoin',
-              '/introduction/ipfs-and-filecoin',
-              '/introduction/filecoin-compared-to',
-              '/introduction/faq'
-            ]
-          },
-          {
-            title: 'How-tos',
-            path: '/how-to/',
-            children: [
-              {
-                title: 'Install Filecoin',
-                sidebarDepth: 1,
-                collapsable: false,
-                children: ['/how-to/install-filecoin', '/how-to/networks']
-              },
-              {
-                title: 'Store Data',
-                sidebarDepth: 1,
-                collapsable: false,
-                children: [
-                  '/how-to/store/prepare-data',
-                  '/how-to/store/tokens',
-                  '/how-to/store/making-storage-deals',
-                  '/how-to/store/retrieving-data',
-                  '/how-to/store/large-files'
-                ]
-              }
-            ]
-          },
-          {
-            title: 'Mine',
-            path: '/mine/',
-            children: [
-              '/mine/storage-mining',
-              '/mine/lotus-seal-worker',
-              '/mine/setting-a-static-port',
-              '/mine/connectivity',
-              '/mine/spacerace',
-              '/mine/mining-troubleshooting'
-            ]
-          },
-          {
-            title: 'Build',
-            path: '/build/',
-            children: [
-              {
-                title: 'Start Building',
-                sidebarDepth: 1,
-                collapsable: false,
-                children: ['/build/start-building/interacting-with-the-network']
-              },
-              {
-                title: 'Core Products',
-                sidebarDepth: 1,
-                collapsable: false,
-                children: [
-                  '/build/core-products/filecoin-backed-pinning-services',
-                  '/build/core-products/powergate',
-                  '/build/core-products/protocol-implementations'
-                ]
-              },
-              {
-                title: 'Developer Tools',
-                sidebarDepth: 1,
-                collapsable: false,
-                children: [
-                  '/build/developer-tools/wallets-signing-tools-api-clients',
-                  [
-                    'https://github.com/filecoin-project/docs/wiki#community-resources',
-                    'Filecoin Community Resources'
-                  ],
-                  ['http://filecoin.onrender.com/', 'Component Design System']
-                ]
-              },
-              {
-                title: 'Examples',
-                sidebarDepth: 1,
-                collapsable: false,
-                children: [
-                  '/build/examples/sample-architectures',
-                  {
-                    title: 'Simple Pinning Service',
-                    sidebarDepth: 2,
-                    collapsable: false,
-                    children: [
-                      '/build/examples/simple-pinning-service/overview',
-                      '/build/examples/simple-pinning-service/powergate-lotus-go-ipfs-interactions',
-                      '/build/examples/simple-pinning-service/step-1-powergate-setup',
-                      '/build/examples/simple-pinning-service/step-2-react-app-setup',
-                      '/build/examples/simple-pinning-service/step-3-connecting-powergate-to-app',
-                      '/build/examples/simple-pinning-service/step-4-explore-pinning-service-app',
-                      '/build/examples/simple-pinning-service/step-5-shut-down-the-application',
-                      '/build/examples/simple-pinning-service/summary'
-                    ]
-                  },
-                  {
-                    title: 'Web Applications',
-                    sidebarDepth: 1,
-                    collapsable: false,
-                    children: ['/build/examples/web-applications/overview']
-                  },
-                  {
-                    title: 'Network Inspector',
-                    sidebarDepth: 2,
-                    collapsable: false,
-                    children: [
-                      'build/examples/network-inspector/overview',
-                      'build/examples/network-inspector/lotus-and-go-ipfs-interactions',
-                      'build/examples/network-inspector/step-1-start-lotus-devnet-and-go-ipfs',
-                      'build/examples/network-inspector/step-2-run-the-react-app',
-                      'build/examples/network-inspector/step-3-set-up-the-lotus-and-go-ipfs-api-clients',
-                      'build/examples/network-inspector/step-4-explore-the-filecoin-network-inspector-app',
-                      'build/examples/network-inspector/step-5-shut-down-the-application',
-                      'build/examples/network-inspector/summary'
-                    ]
-                  },
-                  {
-                    title: 'Meme Marketplace',
-                    sidebarDepth: 2,
-                    collapsable: false,
-                    children: [
-                      'build/examples/meme-marketplace/overview',
-                      'build/examples/meme-marketplace/textile-hub-buckets-and-erc721',
-                      'build/examples/meme-marketplace/step-1-blockchain-and-contracts-setup',
-                      'build/examples/meme-marketplace/step-2-run-react-app',
-                      'build/examples/meme-marketplace/step-3-run-hub-auth-server',
-                      'build/examples/meme-marketplace/step-4-connecting-app-with-auth-server',
-                      'build/examples/meme-marketplace/step-5-connecting-app-with-blockchain',
-                      'build/examples/meme-marketplace/step-6-explore-app',
-                      'build/examples/meme-marketplace/step-7-shut-down-the-application',
-                      'build/examples/meme-marketplace/summary'
-                    ]
-                  }
-                ]
-              }
-            ]
-          },
-
-          {
-            title: 'Reference',
-            path: '/reference/',
-            children: [
-              ['/reference/glossary', 'Glossary'],
-              ['https://github.com/filecoin-project/specs', 'Specification'],
-              ['https://lotu.sh/', 'Lotus tutorial']
-            ]
-          },
-          {
-            title: 'Community',
-            path: '/community/',
-            children: [
-              {
-                title: 'Join the community',
-                sidebarDepth: 2,
-                collapsable: false,
-                children: [
-                  '/community/contribute/ways-to-contribute',
-                  '/community/chat-and-discussion-forums',
-                  ['https://proto.school/#/events', 'ProtoSchool workshops'],
-                  '/community/social-media/social-media'
-                ]
-              },
-              {
-                title: 'Write the docs',
-                sidebarDepth: 1,
-                collapsable: false,
-                children: [
-                  '/community/contribute/grammar-formatting-and-style',
-                  '/community/contribute/writing-guide',
-                  '/community/contribute/contribution-tutorial'
-                ]
-              }
-            ]
-          },
-          {
-            title: 'Project',
-            path: '/project/',
-            children: [
-              [
-                'https://app.instagantt.com/shared/s/1152992274307505/latest',
-                'Roadmap'
-              ],
-              ['https://research.filecoin.io/', 'Research'],
-              '/project/related-projects',
-              [
-                'https://github.com/filecoin-project/community/blob/master/CODE_OF_CONDUCT.md',
-                'Code of conduct'
+        sidebar: {
+          '/mine/': [
+            '/mine/storage-mining',
+            '/mine/lotus-seal-worker',
+            '/mine/setting-a-static-port',
+            '/mine/connectivity',
+            '/mine/spacerace',
+            '/mine/mining-troubleshooting'
+          ],
+          '/build/': [
+            {
+              title: 'Start Building',
+              sidebarDepth: 1,
+              collapsable: false,
+              children: ['/build/start-building/interacting-with-the-network']
+            },
+            {
+              title: 'Core Products',
+              sidebarDepth: 1,
+              collapsable: false,
+              children: [
+                '/build/core-products/filecoin-backed-pinning-services',
+                '/build/core-products/powergate',
+                '/build/core-products/protocol-implementations'
               ]
-            ]
-          }
-        ]
+            },
+            {
+              title: 'Store Data',
+              sidebarDepth: 1,
+              collapsable: false,
+              children: [
+                '/how-to/store/prepare-data',
+                '/how-to/store/tokens',
+                '/how-to/store/making-storage-deals',
+                '/how-to/store/retrieving-data',
+                '/how-to/store/large-files'
+              ]
+            },
+            {
+              title: 'Developer Tools',
+              sidebarDepth: 1,
+              collapsable: false,
+              children: [
+                '/build/developer-tools/wallets-signing-tools-api-clients',
+                [
+                  'https://github.com/filecoin-project/docs/wiki#community-resources',
+                  'Filecoin Community Resources'
+                ],
+                ['http://filecoin.onrender.com/', 'Component Design System']
+              ]
+            },
+            {
+              title: 'Examples',
+              sidebarDepth: 2,
+              collapsable: false,
+              children: [
+                '/build/examples/sample-architectures',
+                {
+                  title: 'Web Applications',
+                  sidebarDepth: 2,
+                  path: '/build/examples/web-applications/overview'
+                },
+                {
+                  title: 'Simple Pinning Service',
+                  sidebarDepth: 2,
+                  path: '/build/examples/simple-pinning-service/overview',
+                  children: [
+                    '/build/examples/simple-pinning-service/powergate-lotus-go-ipfs-interactions',
+                    '/build/examples/simple-pinning-service/step-1-powergate-setup',
+                    '/build/examples/simple-pinning-service/step-2-react-app-setup',
+                    '/build/examples/simple-pinning-service/step-3-connecting-powergate-to-app',
+                    '/build/examples/simple-pinning-service/step-4-explore-pinning-service-app',
+                    '/build/examples/simple-pinning-service/step-5-shut-down-the-application',
+                    '/build/examples/simple-pinning-service/summary'
+                  ]
+                },
+                {
+                  title: 'Network Inspector',
+                  sidebarDepth: 2,
+                  path: '/build/examples/network-inspector/overview',
+                  children: [
+                    '/build/examples/network-inspector/lotus-and-go-ipfs-interactions',
+                    '/build/examples/network-inspector/step-1-start-lotus-devnet-and-go-ipfs',
+                    '/build/examples/network-inspector/step-2-run-the-react-app',
+                    '/build/examples/network-inspector/step-3-set-up-the-lotus-and-go-ipfs-api-clients',
+                    '/build/examples/network-inspector/step-4-explore-the-filecoin-network-inspector-app',
+                    '/build/examples/network-inspector/step-5-shut-down-the-application',
+                    '/build/examples/network-inspector/summary'
+                  ]
+                },
+                {
+                  title: 'Meme Marketplace',
+                  sidebarDepth: 2,
+                  path: '/build/examples/meme-marketplace/overview',
+                  children: [
+                    '/build/examples/meme-marketplace/textile-hub-buckets-and-erc721',
+                    '/build/examples/meme-marketplace/step-1-blockchain-and-contracts-setup',
+                    '/build/examples/meme-marketplace/step-2-run-react-app',
+                    '/build/examples/meme-marketplace/step-3-run-hub-auth-server',
+                    '/build/examples/meme-marketplace/step-4-connecting-app-with-auth-server',
+                    '/build/examples/meme-marketplace/step-5-connecting-app-with-blockchain',
+                    '/build/examples/meme-marketplace/step-6-explore-app',
+                    '/build/examples/meme-marketplace/step-7-shut-down-the-application',
+                    '/build/examples/meme-marketplace/summary'
+                  ]
+                }
+              ]
+            }
+          ],
+          '/reference/': [
+            ['/reference/glossary', 'Glossary'],
+            ['https://github.com/filecoin-project/specs', 'Specification'],
+            ['https://lotu.sh/', 'Lotus tutorial']
+          ],
+          '/': [
+            {
+              title: 'Introduction',
+              path: '/introduction/',
+              children: [
+                '/introduction/new-to-web3',
+                '/introduction/what-is-filecoin',
+                '/introduction/why-filecoin',
+                '/introduction/ipfs-and-filecoin',
+                '/introduction/filecoin-compared-to',
+                '/introduction/faq'
+              ]
+            },
+            {
+              title: 'How-tos',
+              path: '/how-to/',
+              children: [
+                {
+                  title: 'Install Filecoin',
+                  sidebarDepth: 1,
+                  collapsable: false,
+                  children: ['/how-to/install-filecoin', '/how-to/networks']
+                }
+              ]
+            },
+            {
+              title: 'Community',
+              path: '/community/',
+              children: [
+                {
+                  title: 'Join the community',
+                  sidebarDepth: 2,
+                  collapsable: false,
+                  children: [
+                    '/community/contribute/ways-to-contribute',
+                    '/community/chat-and-discussion-forums',
+                    ['https://proto.school/#/events', 'ProtoSchool workshops'],
+                    '/community/social-media/social-media'
+                  ]
+                },
+                {
+                  title: 'Write the docs',
+                  sidebarDepth: 1,
+                  collapsable: false,
+                  children: [
+                    '/community/contribute/grammar-formatting-and-style',
+                    '/community/contribute/writing-guide',
+                    '/community/contribute/contribution-tutorial'
+                  ]
+                }
+              ]
+            },
+            {
+              title: 'Project',
+              path: '/project/',
+              children: [
+                [
+                  'https://app.instagantt.com/shared/s/1152992274307505/latest',
+                  'Roadmap'
+                ],
+                ['https://research.filecoin.io/', 'Research'],
+                '/project/related-projects',
+                [
+                  'https://github.com/filecoin-project/community/blob/master/CODE_OF_CONDUCT.md',
+                  'Code of conduct'
+                ]
+              ]
+            }
+          ]
+        }
       }
     }
   },

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -2,19 +2,6 @@
 
 const DEPLOY_DOMAIN = 'https://docs.filecoin.io'
 
-const getStoreSection = () => ({
-  title: 'Store Data',
-  collapsable: false,
-  path: '/how-to/store/prepare-data/',
-  children: [
-    '/how-to/store/prepare-data',
-    '/how-to/store/tokens',
-    '/how-to/store/making-storage-deals',
-    '/how-to/store/retrieving-data',
-    '/how-to/store/large-files'
-  ]
-})
-
 module.exports = {
   base: '/',
   head: require('./head'),
@@ -105,7 +92,6 @@ module.exports = {
                 'core-products/protocol-implementations'
               ]
             },
-            getStoreSection(),
             {
               title: 'Developer Tools',
               collapsable: false,
@@ -201,7 +187,18 @@ module.exports = {
                   collapsable: false,
                   children: ['/how-to/install-filecoin', '/how-to/networks']
                 },
-                getStoreSection()
+                {
+                  title: 'Store Data',
+                  collapsable: false,
+                  path: '/how-to/store/prepare-data/',
+                  children: [
+                    '/how-to/store/prepare-data',
+                    '/how-to/store/tokens',
+                    '/how-to/store/making-storage-deals',
+                    '/how-to/store/retrieving-data',
+                    '/how-to/store/large-files'
+                  ]
+                }
               ]
             },
             {

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -68,6 +68,7 @@ module.exports = {
         nav: require('./nav/en'),
         sidebar: {
           '/mine/': [
+            '',
             '/mine/storage-mining',
             '/mine/lotus-seal-worker',
             '/mine/setting-a-static-port',
@@ -76,25 +77,23 @@ module.exports = {
             '/mine/mining-troubleshooting'
           ],
           '/build/': [
+            '',
             {
               title: 'Start Building',
-              sidebarDepth: 1,
               collapsable: false,
-              children: ['/build/start-building/interacting-with-the-network']
+              children: ['start-building/interacting-with-the-network']
             },
             {
               title: 'Core Products',
-              sidebarDepth: 1,
               collapsable: false,
               children: [
-                '/build/core-products/filecoin-backed-pinning-services',
-                '/build/core-products/powergate',
-                '/build/core-products/protocol-implementations'
+                'core-products/filecoin-backed-pinning-services',
+                'core-products/powergate',
+                'core-products/protocol-implementations'
               ]
             },
             {
               title: 'Store Data',
-              sidebarDepth: 1,
               collapsable: false,
               children: [
                 '/how-to/store/prepare-data',
@@ -106,10 +105,9 @@ module.exports = {
             },
             {
               title: 'Developer Tools',
-              sidebarDepth: 1,
               collapsable: false,
               children: [
-                '/build/developer-tools/wallets-signing-tools-api-clients',
+                'developer-tools/wallets-signing-tools-api-clients',
                 [
                   'https://github.com/filecoin-project/docs/wiki#community-resources',
                   'Filecoin Community Resources'
@@ -119,19 +117,15 @@ module.exports = {
             },
             {
               title: 'Examples',
-              sidebarDepth: 2,
               collapsable: false,
+              sidebarDepth: 2,
               children: [
-                '/build/examples/sample-architectures',
-                {
-                  title: 'Web Applications',
-                  sidebarDepth: 2,
-                  path: '/build/examples/web-applications/overview'
-                },
+                'examples/sample-architectures',
+                ['examples/web-applications/overview', 'Web Applications'],
                 {
                   title: 'Simple Pinning Service',
-                  sidebarDepth: 2,
                   path: '/build/examples/simple-pinning-service/overview',
+                  collapsable: false,
                   children: [
                     '/build/examples/simple-pinning-service/powergate-lotus-go-ipfs-interactions',
                     '/build/examples/simple-pinning-service/step-1-powergate-setup',
@@ -144,8 +138,8 @@ module.exports = {
                 },
                 {
                   title: 'Network Inspector',
-                  sidebarDepth: 2,
                   path: '/build/examples/network-inspector/overview',
+                  collapsable: false,
                   children: [
                     '/build/examples/network-inspector/lotus-and-go-ipfs-interactions',
                     '/build/examples/network-inspector/step-1-start-lotus-devnet-and-go-ipfs',
@@ -158,8 +152,8 @@ module.exports = {
                 },
                 {
                   title: 'Meme Marketplace',
-                  sidebarDepth: 2,
                   path: '/build/examples/meme-marketplace/overview',
+                  collapsable: false,
                   children: [
                     '/build/examples/meme-marketplace/textile-hub-buckets-and-erc721',
                     '/build/examples/meme-marketplace/step-1-blockchain-and-contracts-setup',
@@ -176,7 +170,7 @@ module.exports = {
             }
           ],
           '/reference/': [
-            ['/reference/glossary', 'Glossary'],
+            'glossary',
             ['https://github.com/filecoin-project/specs', 'Specification'],
             ['https://lotu.sh/', 'Lotus tutorial']
           ],

--- a/docs/.vuepress/nav/en.js
+++ b/docs/.vuepress/nav/en.js
@@ -2,19 +2,5 @@ module.exports = [
   { text: 'Get Started', link: '/' },
   { text: 'Mine', link: '/mine/' },
   { text: 'Build', link: '/build/' },
-  { text: 'Reference', link: '/reference/' },
-  {
-    text: 'Get Involved',
-    ariaLabel: 'Get Involved',
-    items: [
-      {
-        text: 'Project',
-        link: '/project/'
-      },
-      {
-        text: 'Community',
-        link: '/community/'
-      }
-    ]
-  }
+  { text: 'Reference', link: '/reference/' }
 ]

--- a/docs/.vuepress/nav/en.js
+++ b/docs/.vuepress/nav/en.js
@@ -2,5 +2,19 @@ module.exports = [
   { text: 'Get Started', link: '/' },
   { text: 'Mine', link: '/mine/' },
   { text: 'Build', link: '/build/' },
-  { text: 'Reference', link: '/reference/' }
+  { text: 'Reference', link: '/reference/' },
+  {
+    text: 'Get Involved',
+    ariaLabel: 'Get Involved',
+    items: [
+      {
+        text: 'Project',
+        link: '/project/'
+      },
+      {
+        text: 'Community',
+        link: '/community/'
+      }
+    ]
+  }
 ]

--- a/docs/.vuepress/nav/en.js
+++ b/docs/.vuepress/nav/en.js
@@ -1,1 +1,6 @@
-module.exports = []
+module.exports = [
+  { text: 'Get Started', link: '/' },
+  { text: 'Mine', link: '/mine/' },
+  { text: 'Developer', link: '/build/' },
+  { text: 'Reference', link: '/reference/' }
+]

--- a/docs/.vuepress/nav/en.js
+++ b/docs/.vuepress/nav/en.js
@@ -1,6 +1,6 @@
 module.exports = [
   { text: 'Get Started', link: '/' },
   { text: 'Mine', link: '/mine/' },
-  { text: 'Developer', link: '/build/' },
+  { text: 'Build', link: '/build/' },
   { text: 'Reference', link: '/reference/' }
 ]

--- a/docs/.vuepress/theme/components/Breadcrumbs.vue
+++ b/docs/.vuepress/theme/components/Breadcrumbs.vue
@@ -62,7 +62,7 @@ nav
 .breadcrumb
   margin-right: 0.5em
   color: $sidebarTextColor;
-  opacity: 0.5;
+  opacity: 0.7;
   font-weight 600
   transition: opacity 0.5s;
   &:not(:first-child)::before

--- a/docs/.vuepress/theme/components/Breadcrumbs.vue
+++ b/docs/.vuepress/theme/components/Breadcrumbs.vue
@@ -50,7 +50,7 @@ nav
 
   @media (min-width: $MQMobile)
     padding: 1.5rem 0
-    margin: 0 2.5em
+    margin: 0 2.5rem
 
   &.fixed
     position fixed
@@ -61,6 +61,10 @@ nav
     display flex
 .breadcrumb
   margin-right: 0.5em
+  color: $sidebarTextColor;
+  opacity: 0.5;
+  font-weight 600
+  transition: opacity 0.5s;
   &:not(:first-child)::before
     margin-right: 0.5em
     content "/"
@@ -68,5 +72,7 @@ nav
     font-size inherit
 
   &:last-child
-    cursor default
+  &:hover
+    opacity 1
+    color: $accentColor
 </style>

--- a/docs/.vuepress/theme/components/Breadcrumbs.vue
+++ b/docs/.vuepress/theme/components/Breadcrumbs.vue
@@ -1,0 +1,69 @@
+<template>
+  <nav v-if="bread.length > 1" class="breadcrumbs fixed">
+    <div class="nav-wrapper">
+      <router-link
+        class="breadcrumb"
+        v-for="crumb in bread"
+        :key="crumb.path"
+        :to="crumb.path"
+        >{{ crumb.title }}</router-link
+      >
+    </div>
+  </nav>
+</template>
+
+<script>
+export default {
+  name: 'Breadcrumbs',
+  computed: {
+    bread() {
+      const parts = this.$page.path.split('/')
+      if (!parts[parts.length - 1].length) {
+        parts.pop()
+      }
+      let link = ''
+      const crumbs = []
+      for (let i = 0; i < parts.length; i++) {
+        link += parts[i]
+        const page = this.$site.pages.find(
+          el => el.path === link || el.path === link + '/'
+        )
+        link += '/'
+        if (page != null) {
+          crumbs.push({
+            path: page.path,
+            title: i == 0 ? 'Home' : page.frontmatter.breadcrumb || page.title
+          })
+        }
+      }
+      return crumbs
+    }
+  }
+}
+</script>
+
+<style lang="stylus" scoped>
+nav
+  border-bottom 1px solid #eaecef
+  font-size 0.9em
+  padding: 2em 0
+  margin: 0 2.5em
+  &.fixed
+    position fixed
+    z-index 10
+    background-color #fff
+    width 100%
+    max-width 740px
+    display flex
+
+.breadcrumb
+  margin-right: 0.5em
+  &:not(:first-child)::before
+    margin-right: 0.5em
+    content "/"
+    font-family inherit
+    font-size inherit
+
+  &:last-child
+    cursor default
+</style>

--- a/docs/.vuepress/theme/components/Breadcrumbs.vue
+++ b/docs/.vuepress/theme/components/Breadcrumbs.vue
@@ -48,9 +48,9 @@ nav
   font-size 0.9em
   padding: 1.5rem 2rem
 
-  @media (min-width: $MQMobile)
-    padding: 1.5rem 0
+  @media (min-width: $MQNarrow)
     margin: 0 2.5rem
+    padding: 1.5rem 0
 
   &.fixed
     position fixed

--- a/docs/.vuepress/theme/components/Breadcrumbs.vue
+++ b/docs/.vuepress/theme/components/Breadcrumbs.vue
@@ -46,16 +46,19 @@ export default {
 nav
   border-bottom 1px solid #eaecef
   font-size 0.9em
-  padding: 2em 0
-  margin: 0 2.5em
+  padding: 1.5rem 2rem
+
+  @media (min-width: $MQMobile)
+    padding: 1.5rem 0
+    margin: 0 2.5em
+
   &.fixed
     position fixed
-    z-index 10
+    z-index 5
     background-color #fff
     width 100%
     max-width 740px
     display flex
-
 .breadcrumb
   margin-right: 0.5em
   &:not(:first-child)::before

--- a/docs/.vuepress/theme/components/Breadcrumbs.vue
+++ b/docs/.vuepress/theme/components/Breadcrumbs.vue
@@ -32,7 +32,7 @@ export default {
         if (page != null) {
           crumbs.push({
             path: page.path,
-            title: i == 0 ? 'Home' : page.frontmatter.breadcrumb || page.title
+            title: page.frontmatter.breadcrumb || page.title
           })
         }
       }

--- a/docs/.vuepress/theme/components/Page.vue
+++ b/docs/.vuepress/theme/components/Page.vue
@@ -1,7 +1,7 @@
 <template>
   <main class="page">
     <slot name="top" />
-
+    <Breadcrumbs />
     <Content v-if="!isHome" class="theme-default-content" />
     <Home v-else-if="isHome" />
     <div class="content-footer" v-if="!isContentStatus && !isHome">
@@ -26,6 +26,7 @@
 import PageEdit from '@parent-theme/components/PageEdit.vue'
 import PageNav from '@parent-theme/components/PageNav.vue'
 
+import Breadcrumbs from './Breadcrumbs.vue'
 import Feedback from './Feedback.vue'
 import LegacyCallout from './LegacyCallout.vue'
 import Analytics from './Analytics.vue'
@@ -37,6 +38,7 @@ export default {
   components: {
     PageEdit,
     PageNav,
+    Breadcrumbs,
     Feedback,
     LegacyCallout,
     Analytics,
@@ -74,6 +76,10 @@ export default {
 .page {
   padding-bottom: 2rem;
   display: block;
+}
+
+.breadcrumbs.fixed + .theme-default-content {
+  padding-top: 6em;
 }
 
 .content-footer {

--- a/docs/.vuepress/theme/components/Page.vue
+++ b/docs/.vuepress/theme/components/Page.vue
@@ -64,15 +64,17 @@ export default {
     },
     htmlRouteClass: function () {
       // patch to apply a root class for styling elements
+      // any path that isn't a primary nav item will add the route-index class
       const root = document.getElementsByTagName('html')[0]
-      const parts = this.$page.path.split('/')
-      const index = ['introduction', 'how-to', 'project', 'community']
-      index.includes(parts[1])
-        ? root.classList.add('route-index')
-        : root.classList.remove('route-index')
+      const path = this.$page.path
+      const navItems = this.$themeConfig.locales['/'].nav
+        .slice(1)
+        .map(a => a.link)
+      navItems.some(i => path.includes(i))
+        ? root.classList.remove('route-index')
+        : root.classList.add('route-index')
     }
   },
-
   mounted: function () {
     this.smoothScroll()
     this.htmlRouteClass()

--- a/docs/.vuepress/theme/components/Page.vue
+++ b/docs/.vuepress/theme/components/Page.vue
@@ -56,18 +56,30 @@ export default {
   },
   methods: {
     smoothScroll: function () {
-      var root = document.getElementsByTagName('html')[0]
+      const root = document.getElementsByTagName('html')[0]
       // only enable smooth-scrolling on pages shorter that 15000 px
       return root.scrollHeight < 15000
         ? root.classList.add('smooth-scroll')
         : root.classList.remove('smooth-scroll')
+    },
+    htmlRouteClass: function () {
+      // patch to apply a root class for styling elements
+      const root = document.getElementsByTagName('html')[0]
+      const parts = this.$page.path.split('/')
+      const index = ['introduction', 'how-to', 'project', 'community']
+      index.includes(parts[1])
+        ? root.classList.add('route-index')
+        : root.classList.remove('route-index')
     }
   },
+
   mounted: function () {
     this.smoothScroll()
+    this.htmlRouteClass()
   },
   updated: function () {
     this.smoothScroll()
+    this.htmlRouteClass()
   }
 }
 </script>

--- a/docs/.vuepress/theme/styles/header.styl
+++ b/docs/.vuepress/theme/styles/header.styl
@@ -1,6 +1,16 @@
 @media (min-width: $MQNarrow) {
-	header.navbar .links {
+	.navbar {
 		display: flex;
+	}
+
+	.home-link {
+		padding-right: 4rem;
+	}
+
+	header.navbar .links {
+		position: static;
+		flex: 1 1 auto;
+		justify-content: space-between;
 		flex-direction: row-reverse;
 
 		input, .suggestions {

--- a/docs/.vuepress/theme/styles/header.styl
+++ b/docs/.vuepress/theme/styles/header.styl
@@ -1,24 +1,24 @@
 @media (min-width: $MQNarrow) {
-	.navbar {
+	header.navbar {
 		display: flex;
-	}
 
-	.home-link {
-		padding-right: 4rem;
-	}
-
-	header.navbar .links {
-		position: static;
-		flex: 1 1 auto;
-		justify-content: space-between;
-		flex-direction: row-reverse;
-
-		input, .suggestions {
-			width: 10em;
+		.home-link {
+			padding-right: 4rem;
 		}
 
-		input:focus, .suggestions {
-			width: 20em;
+		.links {
+			position: static;
+			flex: 1 1 auto;
+			justify-content: space-between;
+			flex-direction: row-reverse;
+
+			input, .suggestions {
+				width: 10em;
+			}
+
+			input:focus, .suggestions {
+				width: 20em;
+			}
 		}
 	}
 }

--- a/docs/.vuepress/theme/styles/index.styl
+++ b/docs/.vuepress/theme/styles/index.styl
@@ -5,12 +5,7 @@
 @import 'sidebar';
 @import 'video';
 
-// stop sidebar taking up horizontal width and adjusting layout position
 html {
-	@media (min-width: $MQMobile) {
-		margin-left: calc(100vw - 100%);
-	}
-
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 }

--- a/docs/.vuepress/theme/styles/index.styl
+++ b/docs/.vuepress/theme/styles/index.styl
@@ -7,7 +7,12 @@
 
 // stop sidebar taking up horizontal width and adjusting layout position
 html {
-	margin-left: calc(100vw - 100%);
+	@media (min-width: $MQMobile) {
+		margin-left: calc(100vw - 100%);
+	}
+
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
 }
 
 // apply scrolling by default excluding firefox due to trigger issues

--- a/docs/.vuepress/theme/styles/sidebar.styl
+++ b/docs/.vuepress/theme/styles/sidebar.styl
@@ -21,27 +21,16 @@ header.navbar .nav-links {
 	}
 
 	.sidebar-heading {
-		font-weight: 700 !important;
+		font-weight: bold !important;
 	}
 
 	.sidebar-group.is-sub-group a.sidebar-link {
 		margin-bottom: 0.2rem;
 	}
 
-	.sidebar-group.is-sub-group {
-		margin-bottom: 0.5rem;
-	}
-
-	.sidebar-links.sidebar-group-items li:last-child .sidebar-group.is-sub-group {
-		margin-bottom: 0;
-	}
-
 	.sidebar-group.is-sub-group > .sidebar-heading:not(.clickable) {
-		opacity: 1;
-		font-weight: bold;
 		text-transform: uppercase;
 		font-size: 0.8rem;
-		letter-spacing: 0.05em;
 		line-height: 2em;
 	}
 }
@@ -80,6 +69,13 @@ header.navbar .nav-links {
 		overflow: hidden;
 
 		> .sidebar-links {
+			opacity: 0.5;
+			transition: opacity 0.5s;
+
+			&:hover {
+				opacity: 1;
+			}
+
 			overflow: auto;
 			padding-bottom: 6em;
 		}
@@ -95,7 +91,6 @@ header.navbar .nav-links {
 		.nav-item > a:not(.external) {
 			&:hover, &.router-link-active {
 				margin-bottom: 0px;
-				// background: lighten($accentColor, 95%);
 				border-bottom: none;
 				color: $accentColor;
 			}

--- a/docs/.vuepress/theme/styles/sidebar.styl
+++ b/docs/.vuepress/theme/styles/sidebar.styl
@@ -69,10 +69,20 @@ header.navbar .nav-links {
 		overflow: hidden;
 
 		> .sidebar-links {
-			opacity: 0.5;
-			transition: opacity 0.5s;
+			a {
+				&.active {
+					opacity: 1;
 
-			&:hover {
+					a {
+						opacity: 1;
+					}
+				}
+
+				opacity: 0.5;
+				transition: opacity 0.5s;
+			}
+
+			&:hover a {
 				opacity: 1;
 			}
 

--- a/docs/.vuepress/theme/styles/sidebar.styl
+++ b/docs/.vuepress/theme/styles/sidebar.styl
@@ -7,7 +7,19 @@ ul.sidebar-links > li > a {
 	color: inherit;
 }
 
+header.navbar .nav-links {
+	display: none;
+}
+
 .sidebar {
+	.nav-links {
+		display: block !important;
+
+		.nav-item {
+			margin-left: 0;
+		}
+	}
+
 	.sidebar-heading {
 		font-weight: 700 !important;
 	}

--- a/docs/.vuepress/theme/styles/sidebar.styl
+++ b/docs/.vuepress/theme/styles/sidebar.styl
@@ -51,23 +51,54 @@ header.navbar .nav-links {
 }
 
 // sidebar scrollbar style
-.sidebar::-webkit-scrollbar {
+.sidebar-links::-webkit-scrollbar {
 	width: 5px;
 	position: fixed;
 	right: 0;
 }
 
-.sidebar::-webkit-scrollbar-thumb {
+.sidebar-links::-webkit-scrollbar-thumb {
 	background: transparent;
 	transition: background-color 2s;
 }
 
-.sidebar::-webkit-scrollbar-thumb:hover, .sidebar:hover::-webkit-scrollbar-thumb {
+.sidebar-links::-webkit-scrollbar-thumb:hover, .sidebar-links:hover::-webkit-scrollbar-thumb {
 	background: $borderColor;
 }
 
 @media (max-width: $MQMobile) {
 	.sidebar {
 		width: 80vw;
+	}
+}
+
+@media (min-width: $MQMobile) {
+	aside.sidebar {
+		display: flex;
+		flex-direction: column;
+		height: 100vh;
+		overflow: hidden;
+
+		> .sidebar-links {
+			overflow: auto;
+			padding-bottom: 6em;
+		}
+
+		.nav-links, .nav-links a {
+			display: block;
+
+			&:hover, &.router-link-active {
+				color: $textColor;
+			}
+		}
+
+		.nav-item > a:not(.external) {
+			&:hover, &.router-link-active {
+				margin-bottom: 0px;
+				// background: lighten($accentColor, 95%);
+				border-bottom: none;
+				color: $accentColor;
+			}
+		}
 	}
 }

--- a/docs/.vuepress/theme/styles/sidebar.styl
+++ b/docs/.vuepress/theme/styles/sidebar.styl
@@ -67,6 +67,15 @@ header.navbar .nav-links {
 	}
 }
 
+// style selected sidebar item based on route class
+html.route-index {
+	.sidebar .nav-links .nav-item:first-child {
+		a.nav-link {
+			color: $accentColor;
+		}
+	}
+}
+
 @media (min-width: $MQMobile) {
 	aside.sidebar {
 		display: flex;
@@ -100,10 +109,6 @@ header.navbar .nav-links {
 
 		.nav-links, .nav-links a {
 			display: block;
-
-			&:hover, &.router-link-active {
-				color: $textColor;
-			}
 		}
 
 		.nav-item > a:not(.external) {

--- a/docs/.vuepress/theme/styles/sidebar.styl
+++ b/docs/.vuepress/theme/styles/sidebar.styl
@@ -86,7 +86,7 @@ header.navbar .nav-links {
 					}
 				}
 
-				opacity: 0.5;
+				opacity: 0.7;
 				transition: opacity 0.5s;
 			}
 

--- a/docs/.vuepress/theme/styles/sidebar.styl
+++ b/docs/.vuepress/theme/styles/sidebar.styl
@@ -13,6 +13,7 @@ header.navbar .nav-links {
 
 		.nav-item {
 			margin-left: 0;
+			font-size: 1em;
 		}
 	}
 
@@ -74,6 +75,8 @@ header.navbar .nav-links {
 		overflow: hidden;
 
 		> .sidebar-links {
+			padding: 1rem 0;
+
 			a {
 				&.active {
 					opacity: 1;

--- a/docs/.vuepress/theme/styles/sidebar.styl
+++ b/docs/.vuepress/theme/styles/sidebar.styl
@@ -3,15 +3,11 @@ ul > li > a.sidebar-link {
 	font-weight: 500;
 }
 
-ul.sidebar-links > li > a {
-	color: inherit;
-}
-
 header.navbar .nav-links {
 	display: none;
 }
 
-.sidebar {
+#app .sidebar {
 	.nav-links {
 		display: block !important;
 
@@ -20,8 +16,17 @@ header.navbar .nav-links {
 		}
 	}
 
-	.sidebar-heading {
+	.sidebar-group-items {
+		font-size: 1em !important;
+
+		> li .sidebar-link {
+			font-size: 0.95em !important;
+		}
+	}
+
+	> .sidebar-links > li > a.sidebar-link, .sidebar-heading {
 		font-weight: bold !important;
+		font-size: 1em;
 	}
 
 	.sidebar-group.is-sub-group a.sidebar-link {

--- a/docs/.vuepress/theme/styles/sidebar.styl
+++ b/docs/.vuepress/theme/styles/sidebar.styl
@@ -12,10 +12,6 @@ ul.sidebar-links > li > a {
 		font-weight: 700 !important;
 	}
 
-	.sidebar-group .arrow {
-		display: none;
-	}
-
 	.sidebar-group.is-sub-group a.sidebar-link {
 		margin-bottom: 0.2rem;
 	}

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,7 @@
 title: Filecoin Documentation
 description: The homepage for Filecoin documentation.
 homepage: true
+breadcrumb: Home
 ---
 
 # Filecoin Documentation

--- a/docs/mine/README.md
+++ b/docs/mine/README.md
@@ -1,6 +1,7 @@
 ---
 title: Mining in Filecoin
 description: An overview of everything mining-related on the Filecoin network.
+breadcrumb: Mine
 ---
 
 # Mining in Filecoin
@@ -67,10 +68,10 @@ In Filecoin, miners earn two different types of rewards for their efforts: stora
 **Block rewards** are large sums that are given to the miner credited for a new block. Unlike storage fees, these rewards do not come from an associated client; rather, the network "prints" new FIL as both an inflationary measure and an incentive to miners advancing the chain. All active miners on the network have a chance at recieving a block reward, their chance at such being directly proportional to the amount of storage space currently being contributed to the network.
 
 ### WinningPoSt
+
 WinningPoSt is the mechanism by which storage miners are rewarded for their contributions. In the Filecoin network, time is discretized into a series of epochs – the blockchain’s height corresponds to the number of elapsed epochs. At the beginning of each epoch, a small number of storage miners are elected to mine new blocks (Filecoin utilizes tipsets, which permit multiple blocks to be mined at the same height). Each elected miner who successfully creates a block is granted FIL, as well as the opportunity to charge other nodes fees to include messages in the block.
 
 To further incentivize the storage of “useful” data over simple capacity commitments, storage miners have the additional opportunity to compete for special deals offered by verified clients. Such clients are certified with respect to their intent to offer deals involving the storage of meaningful data, and the power a storage miner earns for these deals is augmented by a multiplier. The total amount of power a given storage miner has, after accounting for this multiplier, is known as **quality-adjusted power**.
-
 
 ## Uptime, slashing and penalties
 


### PR DESCRIPTION
Non-breaking primary navigation refactor to prepare for the full documentation restructure.

New content will be added in a future PR along with redirects once we've identified which content will be migrated.

In this PR:
- New `<Breadcrumbs />` component to aid with contextual navigation, esp on mobile pages with the menu collapsed
- New primary navigation concept with sticky top sidebar positioning
- Multiple sidebars to reduce the navigation depth
- New hover actions on sidebar navigation to lower the distraction of the navigation on desktop
- Unified typography style for menu navigation tree
- Added collapsable indicator for sidebar group elements

![2020-08-14 at 19 43 04](https://user-images.githubusercontent.com/106938/90282722-c1f04180-de66-11ea-855a-d71fecc5c964.png)

TODO:
- [x] Fix "Getting Started" active router link
- [x] Refine responsive styles
- [x] Browser testing

ref: #154 #193 