### PR TITLE
feat: auto-scroll sidebar active item into view

### DIFF
--- a/docs/.vuepress/theme/components/ScrollPatch.vue
+++ b/docs/.vuepress/theme/components/ScrollPatch.vue
@@ -2,7 +2,7 @@
 <script>
 export default {
   methods: {
-    scrollTop: function() {
+    scrollTop: function () {
       // FireFox has a problem setting the correct scroll postion on route change this patch will fix it for now
       if (navigator.userAgent.toLowerCase().indexOf('firefox') > -1) {
         window.scrollTo(0, 0)
@@ -13,8 +13,24 @@ export default {
     }
   },
   watch: {
-    '$route.path': function(path) {
+    '$route.path': function (path) {
       this.scrollTop()
+    },
+    $route: function () {
+      // activates on every route change
+      const items = document.querySelectorAll('.sidebar-links .active')
+      if (items.length && document.documentElement.scrollIntoView) {
+        const lastItem = items.item(items.length - 1)
+        try {
+          lastItem.scrollIntoView({
+            behavior: 'smooth',
+            block: 'center',
+            inline: 'nearest'
+          })
+        } catch (e) {
+          lastItem.scrollIntoView(false)
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
For pages with very long indexes it is easy to lose your location in the tree, this feature ensures the display is synchronised as you scroll so you can easily follow the TOC 💫

🧪  This uses the experimental [`Element.scrollIntoView`](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView) API so it may now work in all browsers but will fallback to default behaviour in those cases.

![2020-08-20 at 15 07 00](https://user-images.githubusercontent.com/106938/90782823-36a7fd80-e2f7-11ea-9893-ef10464e5802.gif)
