### PR TITLE
Replace all reference of lotus-storage-miner with lotus-miner

### DIFF
--- a/docs/community/contribute/grammar-formatting-and-style.md
+++ b/docs/community/contribute/grammar-formatting-and-style.md
@@ -186,9 +186,9 @@ Write command-line inputs without any other characters. Precede outputs from the
 
 ````markdown
     ```bash
-    lotus-storage-miner info
+    lotus-miner info
 
-    > ~/lotus> lotus-storage-miner info
+    > ~/lotus> lotus-miner info
     > Miner: t0103
     > Sector Size: 16.0 MiB
     > Power: 0 B / 16.0 MiB (0%)
@@ -204,9 +204,9 @@ Command-line examples can be truncated with three periods `...` to remove extran
 
 ````markdown
     ```bash
-    lotus-storage-miner info
+    lotus-miner info
 
-    > ~/lotus> lotus-storage-miner info
+    > ~/lotus> lotus-miner info
     > Miner: t0103
     > Sector Size: 16.0 MiB
     > ...

--- a/docs/how-to/store/large-files.md
+++ b/docs/how-to/store/large-files.md
@@ -69,7 +69,7 @@ This can be done several ways, such as shipping hard drives from the client to t
 The miner can import the data and deal manually with:
 
 ```            
-lotus-storage-miner deals import-data <dealCid> <filePath>
+lotus-miner deals import-data <dealCid> <filePath>
 ```
 
 Once the first Proof of Spacetime (PoSt) hits the chain, the storage deal is considered active. 

--- a/docs/mine/connectivity.md
+++ b/docs/mine/connectivity.md
@@ -24,7 +24,7 @@ You can set the multiaddresses that your miner listens on in a miner's `config.t
 Once you've done so, you can set the on-chain record of your miner's listen addresses with the command:
 
 ```
-lotus-storage-miner actor set-addrs <multiaddr_1> <multiaddr_2> ... <multiaddr_n>
+lotus-miner actor set-addrs <multiaddr_1> <multiaddr_2> ... <multiaddr_n>
 ```
 
 This updates the `MinerInfo` object in your miner's actor, which will be looked up when a client attempts to make a deal with you. You can provide any number of addresses.
@@ -32,7 +32,7 @@ This updates the `MinerInfo` object in your miner's actor, which will be looked 
 As an example, you could run:
 
 ```
-lotus-storage-miner actor set-addrs /ip4/123.123.73.123/tcp/12345 /ip4/223.223.83.223/tcp/23456
+lotus-miner actor set-addrs /ip4/123.123.73.123/tcp/12345 /ip4/223.223.83.223/tcp/23456
 ```
 
 This step is the best way to ensure your miner is dial-able for storage and retrieval deals!
@@ -42,13 +42,13 @@ This step is the best way to ensure your miner is dial-able for storage and retr
 To ensure storage and retrieval deals operate smoothly, it is recommended to check how many peers a miner is connected to after each start-up. In the Lotus client, a manual peer check can be performed with the command:
 
 ```
-lotus-storage-miner net peers
+lotus-miner net peers
 ```
 
 If a very low peer count is present (1-5), it is possible to manually connect the miner to the DHT by utilising one of the bootstrap peers listed in the branch's `./build/bootstrap/bootstrappers.pi` file with the commmand:
 
 ```
-lotus-storage-miner net connect <address1> <address2>…
+lotus-miner net connect <address1> <address2>…
 ```
 
 ## Port forwarding

--- a/docs/mine/lotus-seal-worker.md
+++ b/docs/mine/lotus-seal-worker.md
@@ -24,7 +24,7 @@ make lotus-seal-worker
 
 ## Setting up the Storage Miner
 
-First, you will need to ensure your `lotus-storage-miner`'s API is accessible over the network.
+First, you will need to ensure your `lotus-miner`'s API is accessible over the network.
 
 To do this, open up `~/.lotusstorage/config.toml` (Or if you manually set `LOTUS_STORAGE_PATH`, look under that directory) and look for the API field.
 
@@ -56,10 +56,10 @@ lotus-seal-worker run --address 192.168.2.10:2345
 
 Replace `192.168.2.10:2345` with the proper IP and port.
 
-To check that the **Lotus Seal Worker** is connected to your **Lotus Storage Miner**, run `lotus-storage-miner workers list` and check that the remote worker count has increased.
+To check that the **Lotus Seal Worker** is connected to your **Lotus Storage Miner**, run `lotus-miner workers list` and check that the remote worker count has increased.
 
 ```sh
-why@computer ~/lotus> lotus-storage-miner workers list
+why@computer ~/lotus> lotus-miner workers list
 Worker 0, host computer
         CPU:  [                                                                ] 0 core(s) in use
         RAM:  [||||||||||||||||||                                              ] 28% 18.1 GiB/62.7 GiB

--- a/docs/mine/mining-troubleshooting.md
+++ b/docs/mine/mining-troubleshooting.md
@@ -20,12 +20,12 @@ The **Bellman** lockfile is created to lock a GPU for a process. This bug can oc
 mining block failed: computing election proof: github.com/filecoin-project/lotus/miner.(*Miner).mineOne
 ```
 
-This bug occurs when the storage miner can't acquire the `bellman.lock`. To fix it you need to stop the `lotus-storage-miner` and remove `/tmp/bellman.lock`.
+This bug occurs when the storage miner can't acquire the `bellman.lock`. To fix it you need to stop the `lotus-miner` and remove `/tmp/bellman.lock`.
 
 ## Error: Failed to get api endpoint
 
 ```sh
-lotus-storage-miner info
+lotus-miner info
 # WARN  main  lotus-storage-miner/main.go:73  failed to get api endpoint: (/Users/myrmidon/.lotusstorage) %!w(*errors.errorString=&{API not running (no endpoint)}):
 ```
 
@@ -42,7 +42,7 @@ If you see this, that means your computer is too slow and your blocks are not in
 ## Error: No space left on device
 
 ```sh
-lotus-storage-miner sectors pledge
+lotus-miner sectors pledge
 # No space left on device (os error 28)
 ```
 

--- a/docs/mine/storage-mining.md
+++ b/docs/mine/storage-mining.md
@@ -10,7 +10,7 @@ It is useful to [join the Testnet](https://docs.lotu.sh/en+join-testnet) prior t
 
 ## Note: Using the Lotus Storage Miner from China
 
-If you are trying to use `lotus-storage-miner` from China. You should set this **environment variable** on your machine.
+If you are trying to use `lotus-miner` from China. You should set this **environment variable** on your machine.
 
 ```sh
 IPFS_GATEWAY="https://proof-parameters.s3.cn-south-1.jdcloud-oss.com/ipfs/"
@@ -33,7 +33,7 @@ $ lotus wallet new bls
 Initialize your Lotus node as miner:
 
 ```bash
-$ lotus-storage-miner init --owner=t3qjqisfrvadkraeqp3jlru4sfayakztcq4rt2mbx2uwflluuxchht6tp4i4q2egvmjodrvr2x76bgrlu3zgkq --sector-size=32GiB
+$ lotus-miner init --owner=t3qjqisfrvadkraeqp3jlru4sfayakztcq4rt2mbx2uwflluuxchht6tp4i4q2egvmjodrvr2x76bgrlu3zgkq --sector-size=32GiB
 
 2020-08-18T07:41:23.917-0700    INFO    main    lotus-storage-miner/init.go:110 Initializing lotus storage miner
 2020-08-18T07:41:23.917-0700    INFO    main    lotus-storage-miner/init.go:130 Checking proof parameters
@@ -47,7 +47,7 @@ This process will take about 10 minutes to finish. Eventually it will say someth
 
 ```bash
 2020-08-18T07:59:10.475-0700    INFO    badger  v2@v2.0.3/levels.go:888 Got compaction priority: {level:0 score:1.73 dropPrefix:[]}
-2020-08-18T07:59:10.478-0700    INFO    main    lotus-storage-miner/init.go:252 Storage miner successfully created, you can now start it with 'lotus-storage-miner run'
+2020-08-18T07:59:10.478-0700    INFO    main    lotus-storage-miner/init.go:252 Storage miner successfully created, you can now start it with 'lotus-miner run'
 ```
 
 ## Mining
@@ -55,7 +55,7 @@ This process will take about 10 minutes to finish. Eventually it will say someth
 To mine:
 
 ```bash
-$ lotus-storage-miner run
+$ lotus-miner run
 
 2020-08-18T08:00:29.590-0700    INFO    main    lotus-storage-miner/run.go:81   Checking full node sync status
 Worker 0: Target: [bafy2bzacecrxfiiy2lsb5covivnvrv6nihpihqm7s5mzpw7bjzvhsmzsjuv5e]      State: complete Height: 209461
@@ -68,14 +68,14 @@ If you are downloading **Filecoin Proof Parameters**, the download can take some
 Get information about your miner:
 
 ```sh
-$ lotus-storage-miner info
+$ lotus-miner info
 # example: miner id `t0111`
 ```
 
 **Seal** random data to start producing **PoSts**:
 
 ```sh
-$ lotus-storage-miner sectors pledge
+$ lotus-miner sectors pledge
 ```
 
 - Warning: On Linux configurations, this command will write data to `$TMPDIR` which is not usually the largest partition. You should point the value to a larger partition if possible.
@@ -95,11 +95,11 @@ $ lotus state sectors <miner>
 
 ### `FIL_PROOFS_MAXIMIZE_CACHING=1` Environment variable
 
-This env var can be used with `lotus-storage-miner`, `lotus-seal-worker`, and `lotus-bench` to make the precommit1 step faster at the cost of some memory use (1x sector size)
+This env var can be used with `lotus-miner`, `lotus-seal-worker`, and `lotus-bench` to make the precommit1 step faster at the cost of some memory use (1x sector size)
 
 ### `FIL_PROOFS_USE_GPU_COLUMN_BUILDER=1` Environment variable
 
-This env var can be used with `lotus-storage-miner`, `lotus-seal-worker`, and `lotus-bench` to enable experimental precommit2 GPU acceleration
+This env var can be used with `lotus-miner`, `lotus-seal-worker`, and `lotus-bench` to enable experimental precommit2 GPU acceleration
 
 ### Setting multiaddresses
 
@@ -111,7 +111,7 @@ The addresses passed to `set-addrs` parameter in the commands below should be cu
 Once the config file has been updated, set the on-chain record of the miner's listen addresses:
 
 ```
-lotus-storage-miner actor set-addrs <multiaddr_1> <multiaddr_2> ... <multiaddr_n>
+lotus-miner actor set-addrs <multiaddr_1> <multiaddr_2> ... <multiaddr_n>
 ```
 
 This updates the `MinerInfo` object in the miner's actor, which will be looked up
@@ -120,5 +120,5 @@ when a client attempts to make a deal. Any number of addresses can be provided.
 Example:
 
 ```
-$ lotus-storage-miner actor set-addrs /ip4/123.123.73.123/tcp/12345 /ip4/223.223.83.223/tcp/23456
+$ lotus-miner actor set-addrs /ip4/123.123.73.123/tcp/12345 /ip4/223.223.83.223/tcp/23456
 ```


### PR DESCRIPTION
The `lotus-storage-miner` command does not exist anymore and was renamed to `lotus-miner`.