### PR TITLE
Removes the contents menu from this page.

### DIFF
--- a/docs/build/start-building/interacting-with-the-network.md
+++ b/docs/build/start-building/interacting-with-the-network.md
@@ -5,21 +5,6 @@ description: Learn how to interface with the Filecoin network.
  
 # Interacting with the network
 
-<br>
-
-  - [Mainnet](#mainnet)
-  - [Testnet](#testnet)
-     - [Filecoin Space Race competition](#filecoin-space-race-competition)
-     - [Running hosted endpoints](#running-hosted-endpoints)
-     - [Hosted nodes for testnet](#hosted-nodes-for-testnet)
-     - [Running a local network](#running-a-local-network)
-     - [Running Powergate](#running-powergate)
-  - [Devnets](#devnets)
-     - [Nerpa Devnet](#nerpa-devnet) - `for Developers building apps`
-     - [Calibration Devnet](#calibration-devnet) - `for preparing for the Space Race`
-
-<br>
-
 This page outlines various options for connecting to local and remote test networks while building and operating your service or application.
 
 Each Filecoin-based service or application will need to use at least one Filecoin node that maintains consensus. All interactions with the network must flow through an up-to-date node: sending and receiving market deals, sending and receiving data, and more.


### PR DESCRIPTION
The contents of this page is shown in the sidebar, so the contents menu at the top isn't necessary.

![image](https://user-images.githubusercontent.com/9611008/91460781-9dc93300-e85e-11ea-91bf-94c2141598b5.png).