### PR TITLE
Update Slack join link & reward tiers

### DIFF
--- a/docs/community/README.md
+++ b/docs/community/README.md
@@ -17,7 +17,7 @@ The official [Filecoin forums](https://discuss.filecoin.io/) are the primary hom
 
 ## Community chat
 
-For short-lived discussions, join our community chat directly on [Slack](https://join.slack.com/t/filecoinproject/shared_invite/zt-dj58b7fq-weyaTEvjHoYF_ENkQHR6Ig) or via a bridge from [Matrix](https://riot.im/app/#/group/+filecoin:matrix.org).
+For short-lived discussions, join our community chat directly on [Slack](https://filecoin.io/slack) or via a bridge from [Matrix](https://riot.im/app/#/group/+filecoin:matrix.org).
 
 ## ProtoSchool workshops
 

--- a/docs/mine/spacerace.md
+++ b/docs/mine/spacerace.md
@@ -23,7 +23,7 @@ You'll also need to complete these steps to be eligible for rewards:
 - Demonstrate at least one [sector upgrade](#how-do-i-demonstrate-a-sector-upgrade) per miner.
 - Register your miner(s) by submitting your individual or company info via the [Competition Dashboard](https://spacerace.filecoin.io/), **before 22:00 UTC, Monday, August 31st**. It will generate a message for your miner to sign and submit. Miners that qualify for rewards will also need to pass an AML/KYC check after the competition ends.
 
-For help or additional questions, join the [#space-race](https://filecoinproject.slack.com/archives/C0179RNEMU4) channel on the Filecoin Slack.
+For help or additional questions, join the [#space-race](https://filecoinproject.slack.com/archives/C0179RNEMU4) channel on the [Filecoin Slack](https://filecoin.io/slack).
 
 ## What are the possible rewards?
 

--- a/docs/mine/spacerace.md
+++ b/docs/mine/spacerace.md
@@ -45,8 +45,8 @@ The top 50 miners in each region and globally are eligible to split a reward poo
 
 | Total FIL rewards (regional pool) | Regional network storage achieved |
 | --------------------------------- | --------------------------------- |
-| 25k FIL                           | 100 TiB                           |
-| 50k FIL                           | 500 TiB                           |
+| 25k FIL                           | 10 TiB                           |
+| 50k FIL                           | 100 TiB                           |
 | 100k FIL                          | 1 PiB                             |
 | 250k FIL                          | 5 PiB                             |
 | 500k FIL                          | 10 PiB                            |


### PR DESCRIPTION
- Fix 2 outdated links with new shortcut that includes join token: https://filecoin.io/slack
- Update first 2 reward tier sizes