### PR TITLE
Add upgrade instructions

### DIFF
--- a/docs/store/lotus/upgrades.md
+++ b/docs/store/lotus/upgrades.md
@@ -7,3 +7,22 @@ breadcrumb: 'Upgrades'
 # {{ $frontmatter.title }}
 
 {{ $frontmatter.description }}
+
+If you installed Lotus on your machine, first you have to delete the configuration folder located at `~/.lotus` (or if you manually set `LOTUS_PATH`, look under that directory).
+
+```bash
+rm -rf ~/.lotus # or $LOTUS_PATH
+```
+
+Then you can upgrade to the latest version by going to Lotus directory and executing the following commands:
+
+```bash
+# get the latest
+git pull origin master
+
+# clean and remake the binaries
+make clean && make build
+
+# instal binaries in correct location
+make install # or sudo make install if necessary
+```


### PR DESCRIPTION
Closes #392

## Changes

- added upgrade section from Lotus with steps to delete `~/.lotus` folder

## Preview

![image](https://user-images.githubusercontent.com/706078/92658232-99742f80-f2cc-11ea-91ec-7ffd79e0da7d.png)
