### PR TITLE
Adds Custom containers to contribution guidelines.

### DIFF
--- a/docs/community/contribute/grammar-formatting-and-style.md
+++ b/docs/community/contribute/grammar-formatting-and-style.md
@@ -270,6 +270,50 @@ Press `ctrl` + `c` to copy the highlighted text.
 
 The plus symbol `+` stays outside of the code tags.
 
+#### Custom containers
+
+Custom containers can be defined by their types, titles, and contents.
+
+##### Input
+
+```markdown
+::: tip
+This is a tip
+:::
+
+::: warning
+This is a warning
+:::
+
+::: danger
+This is a dangerous warning
+:::
+
+::: details
+This is a details block, which does not work in IE / Edge
+:::
+```
+
+##### Output
+
+This output is not supported by Github Flavoured Markdown (GFM). However, they render properly when viewed through VuePress at [docs.filecoin.io/community/contribute/grammar-formatting-and-style](https://docs.filecoin.io/community/contribute/grammar-formatting-and-style/#style).
+
+::: tip
+This is a tip
+:::
+
+::: warning
+This is a warning
+:::
+
+::: danger
+This is a dangerous warning
+:::
+
+::: details
+This is a details block, which does not work in IE / Edge
+:::
+
 ### Images
 
 The following rules and guidelines define how to use and store images.

--- a/docs/community/contribute/grammar-formatting-and-style.md
+++ b/docs/community/contribute/grammar-formatting-and-style.md
@@ -296,7 +296,7 @@ This is a details block, which does not work in IE / Edge
 
 ##### Output
 
-This output is not supported by Github Flavoured Markdown (GFM). However, they render properly when viewed through VuePress at [docs.filecoin.io/community/contribute/grammar-formatting-and-style](https://docs.filecoin.io/community/contribute/grammar-formatting-and-style/#style).
+This output is not supported by Github Flavoured Markdown (GFM). However, they render properly when viewed through VuePress at [docs.filecoin.io/community/contribute/grammar-formatting-and-style](https://docs.filecoin.io/community/contribute/grammar-formatting-and-style/#custom-containers).
 
 ::: tip
 This is a tip


### PR DESCRIPTION
Adds a tiny section in the contribution guidelines for how to use the `:::tip:::` and `:::warning:::` blocks. @hsanjuan you requested this like 2 weeks ago, but I forgot about it until now.