### PR TITLE
Remove out-of-context warning about 0.7.1

### DIFF
--- a/docs/get-started/lotus/installation.md
+++ b/docs/get-started/lotus/installation.md
@@ -111,10 +111,6 @@ Once all the dependencies are installed, you can build and install the Lotus sui
    sudo make install
    ```
 
-   ::: warning
-   Lotus 0.7.1 has a bug and will crash on processors without support for `adx` instruction (Intel, older AMD) not work.
-   :::
-
    This will put `lotus`, `lotus-miner` and `lotus-worker` in `/usr/local/bin`.
 
    `lotus` will use the `$HOME/.lotus` folder by default for storage (configuration, chain data, wallets, etc). See [advanced options](configuration-and-advanced-usage.md) for information on how to customize the Lotus folder.


### PR DESCRIPTION
Cannot just warn that 0.7.1 is broken on intel. Previous steps already explains how to workaround it and what the issue is.