### PR TITLE
fix: inbound 404s

### DIFF
--- a/docs/.vuepress/public/_redirects
+++ b/docs/.vuepress/public/_redirects
@@ -35,7 +35,9 @@
 /build/start-building/interacting-with-the-network/ /build/
 /build/start-building/deploy-your-application-to-the-filecoin-testnet/ /build/onboard-testnet/
 /build/start-building/implementations/ /get-started/
-/build/examples/sample-architectures/ /build/examples/ 
+/build/examples/sample-architectures/ /build/examples/
+
+/store/lotus/send-and-receive-fil/ /get-started/lotus/send-and-receive-fil/
 
 /build/tools/ /build/
 /build/tools/api-clients/ /build/lotus/api-client-libraries/

--- a/docs/.vuepress/public/_redirects
+++ b/docs/.vuepress/public/_redirects
@@ -35,6 +35,7 @@
 /build/start-building/interacting-with-the-network/ /build/
 /build/start-building/deploy-your-application-to-the-filecoin-testnet/ /build/onboard-testnet/
 /build/start-building/implementations/ /get-started/
+/build/examples/sample-architectures/ /build/examples/ 
 
 /build/tools/ /build/
 /build/tools/api-clients/ /build/lotus/api-client-libraries/

--- a/docs/.vuepress/public/_redirects
+++ b/docs/.vuepress/public/_redirects
@@ -17,7 +17,7 @@
 /how-to/join-a-network/ /get-started/lotus/installation/
 /how-to/store/prepare-data/ /store/lotus/store-data/
 /how-to/store/tokens/ /get-started/lotus/send-and-receive-fil/
-/how-to/store/making-storage-deals/ /mine/lotus/storage-data/
+/how-to/store/making-storage-deals/ /mine/lotus/store-data/
 /how-to/store/retrieving-data/ /store/lotus/retrieve-data/
 /how-to/store/large-files/ /store/lotus/very-large-files/
 

--- a/docs/build/onboard-testnet.md
+++ b/docs/build/onboard-testnet.md
@@ -15,7 +15,7 @@ The Filecoin testnet is a network with parameters and activity levels _as close 
 ::: tip
 **We recommend that most developers use a hosted service** like [hosted Powergates or Textile Buckets](README.md#filecoin-backed-storage-providers) to store application data to the Filecoin testnet. These services are by far the fastest and friendliest way to get your application working with Filecoin. If you are using either a hosted [Powergate](powergate.md) or Textile Buckets, you don’t need to worry about any of the information in this guide. Textile’s services are soon to be deployed against the Filecoin testnet. If you are using hosted Textile products, your application will also be deployed on the Filecoin testnet.
 
-If you would like accelerated access to a hosted Powergate instance, please fill out [this form](https://blog.textile.io/hosted-powergate//f5Vd5kTNYTKrmj1D8). We will work with the Textile team to get you access to a hosted Powergate asap.
+If you would like accelerated access to a hosted Powergate instance, please fill out [this form](https://blog.textile.io/hosted-powergate). We will work with the Textile team to get you access to a hosted Powergate asap.
 :::
 
 **If you are managing your own Filecoin nodes, whether your own lotus node or Powergate node, please read on for these important details.**

--- a/docs/get-started/lotus/troubleshooting.md
+++ b/docs/get-started/lotus/troubleshooting.md
@@ -80,7 +80,7 @@ If you get a `signal killed` error, it could indcate that there was an error dur
 make: *** [Makefile:68: lotus] Error 1
 ```
 
-Double check that your computer meets the [minimum hardware requirements](./installation#minimal-requirements) for Lotus.
+Double check that your computer meets the [minimum hardware requirements](./installation.md#minimal-requirements) for Lotus.
 
 ## Go command not found
 

--- a/docs/mine/lotus/miner-lifecycle.md
+++ b/docs/mine/lotus/miner-lifecycle.md
@@ -153,7 +153,7 @@ If you wish to change any of the storage locations of the Lotus miner, follow th
 5. Start the miner.
 6. Verify that things are working correctly. If so, you can discard the old copy.
 
-If you wish to expand your storage, while keeping the current, you can always [add additional storage locations to a Lotus miner](custom-storage-layout) with `lotus storage attach` (see `--help`).
+If you wish to expand your storage, while keeping the current, you can always [add additional storage locations to a Lotus miner](custom-storage-layout.md) with `lotus storage attach` (see `--help`).
 
 If you wish to change the storage location for any of the lotus workers:
 


### PR DESCRIPTION
Redirects to capture top inbound 404s since docs restructure. There is no referrer to fix upstream so a 301 should fix it for now.

![2020-10-08 at 14 15 16](https://user-images.githubusercontent.com/106938/95463732-0680f080-0971-11eb-95de-8d55c587fe55.png)
