### PR TITLE
Move gas documentation to how-filecoin-works

### DIFF
--- a/docs/about-filecoin/how-filecoin-works.md
+++ b/docs/about-filecoin/how-filecoin-works.md
@@ -50,6 +50,33 @@ Once a deal is active and during its full lifetime, the miner will use _Proof of
 
 Filecoin clients and other miners continuously verify that the proofs included in each block are valid, providing the necessary security and penalizing miners that do not honor their deals.
 
+## Gas fees
+
+Executing messages, for example by including transactions or proofs in the chain, consumes both computation and storage resources on the network. _Gas_ is a measure of resources consumed by messages. The gas consumed by a message directly affects the cost that the sender has to pay for it to be included in a new block by a miner.
+
+Historically in other blockchains, miners specify a GasFee in a unit of native currency and then pay the block producing miners a priority fee based on how much gas is consumed by the message. Filecoin works similarly, except an amount of the fees is burned (sent to an irrecoverable address) to compensate for the network expenditure of resources, since all nodes need to validate the messages. The idea is based on Ethereum's [EIP1559](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1559.md).
+
+The amount of fees burned in the Filecoin network comes given by a dynamic \*_*BaseFee*_ which gets automatically adjusted according to the network congestion parameters (block sizes). The current value can be obtained from one of the [block explorers](../get-started/explore-the-network.md) or by [inspecting the current head](../mine/lotus/message-pool.md).
+
+Additionally, a number of gas-related parameters are attached to each message and determine the amount of rewards that miners get. Here's an overview of the terms and concepts:
+
+- **_GasUsage_**: the amount of gas that a message's execution actually consumes. Current protocol does not know how much gas a message will exactly consume ahead of execution, but it can be estimated (see [prices](https://github.com/filecoin-project/lotus/blob/d678fe4bfa5b4c70bcebd46cdc38aafc452b42d1/chain/vm/gas.go#L87)). GasUsage measured in units of _Gas_.
+- **_BaseFee_**: the amount of FIL that gets burned _per unit of gas consumed_ for the execution of every message. It is measured in units of attoFIL/Gas.
+- **_GasLimit_**: the limit on the amount of gas that a message's execution can consume, estimated and specified by a message sender. It is measured in units of Gas. The sum of _GasLimit_ for all messages included in a block must not exceed the _BlockGasLimit_. Messages will fail to execute if they run out of _Gas_, and any effects of the execution will be reverted.
+- **_GasFeeCap_**: the maximum token amount that a sender is willing to pay per GasUnit for including a message in a block. It is measured in units of attoFIL/Gas. A message sender must have a minimum balance of _GasFeeCap \* GasLimit_ when sending a message, even though not all of that will be consumed. _GasFeeCap_ can serve as a safeguard agains high, unexpected _BaseFee_ fluctuations.
+- **_GasPremium_**: a priority fee that is paid to the block-producing miner. This is capped by _GasFeeCap_. The _BaseFee_ has a higher priority. It is measured in units of attoFIL/Gas and can be as low as 1 attoFIL/Gas.
+- **_Overestimation burn_**: an additional amount of gas to burn that grows larger when the difference between _GasLimit_ and _GasUsage_ is large. See [current implementation](https://github.com/filecoin-project/lotus/blob/v0.10.0/chain/vm/burn.go#L38)).
+
+The total cost of a message for a sender will be:
+
+- _GasUsage \* BaseFee_ FIL (burned) **+**
+- _GasLimit \* GasPremium_ FIL (miner's reward) **+**
+- _OverEstimationBurn \* BaseFee_ FIL
+
+An important detail is that a message will always pay the _burn fee_, regardless of the _GasFeeCap_ used. Thus, a low _GasFeeCap_ may result in a reduced _GasPremium_ or even a negative one! In that case, the miners that include a message will have to pay the needed amounts out of their own pockets, which means they are unlikely to include such messages in new blocks.
+
+Filecoin implementations may choose the heuristics of how their miners select messages for inclusion in new blocks, but they will usually [attempt to maximize the miner's rewards](../mine/lotus/message-pool.md).
+
 ## Additional materials
 
 Filecoin is built on top of [mature projects](../project/related-projects/) like libp2p (networking, addressing, message distribution), IPLD (data formats, encoding, and content-addressed data structures), IPFS (data transfers), and multiformats (future-proof data types).
@@ -71,3 +98,4 @@ Here are some links to useful introductory materials about the technology that p
   - [Introducing Filecoin, a decentralized storage network](https://www.youtube.com/watch?v=EClPAFPeXIQ)
   - [Filecoin primer](https://ipfs.io/ipfs/QmWimYyZHzChb35EYojGduWHBdhf9SD5NHqf8MjZ4n3Qrr/Filecoin-Primer.7-25.pdf)
   - [Building the Filecoin ecosystem](https://youtu.be/SXlTBvcqzz8)
+  - [Filecoin features: gas fees](https://filecoin.io/blog/filecoin-features-gas-fees/)

--- a/docs/get-started/lotus/send-and-receive-fil.md
+++ b/docs/get-started/lotus/send-and-receive-fil.md
@@ -24,17 +24,33 @@ This will print your Filecoin address.
 Your wallet information is stored in the `~/.lotus/keystore` (or `$LOTUS_PATH/keystore`). For instructions on export/import, see below.
 :::
 
+## Listing wallets
+
+You can create as many wallets as you need. One of them, will be the _default wallet_. You can list all wallets with:
+
 You can create multiple wallets and list them with:
 
 ```bash
 lotus wallet list
 ```
 
+You can see the default wallet with:
+
+```bash
+lotus wallet default
+```
+
+If you wish, you can change the default wallet to a different one:
+
+```bash
+lotus wallet set-default <address>
+```
+
 ## Obtaining FIL
 
-FIL can be obtained either by using one of the Faucets (check URLs in the [Networks dashboard](https://networks.filecoin.io) or by buying it from an exchange supporting FIL trading (once mainnet has launched).
+FIL for non-mainnet networks can usually be obtained by using one of the Faucets (check URLs in the [Networks dashboard](https://networks.filecoin.io). For mainnet, the easiest is to buy FIL from an exchange supporting FIL-trading.
 
-Once you have received some FIL you can check your balance with:
+Once you have received some FIL, you can check your balance with:
 
 ```bash
 lotus wallet balance
@@ -44,22 +60,10 @@ Remember that your will only see the latest balance when your daemon is fully sy
 
 ## Sending FIL
 
-Send FIL from the default wallet by running:
+Send FIL from the _default wallet_ by running:
 
 ```bash
 lotus send <target address> <amount>
-```
-
-To get the current default wallet address:
-
-```bash
-lotus wallet default
-```
-
-To set the default wallet address to a different address:
-
-```bash
-lotus wallet set-default <address>
 ```
 
 To send FIL from a specific wallet:
@@ -69,8 +73,10 @@ lotus send --from=<sender address> <target address> <amount>
 ```
 
 :::tip
-Make sure to check `lotus send --help` for advanced options.
+Make sure to check `lotus send --help` for advanced options, like setting a limit to the price of fees.
 :::
+
+Every transaction sending FIL pays an additional fee based on its _gas_ usage. Gas and fees are explained in the [How Filecoin Works guide](../../about-filecoin/how-filecoin-works.md). By default, Lotus automatically sets all the necessary values, but you may want to use the `--gas-feecap` flag in the `send` command to avoid surprises when network congestion is high. For more information about messages, see the [Message Pool guide](../../mine/lotus/message-pool.md).
 
 ## Exporting and importing a wallet
 

--- a/docs/mine/lotus/message-pool.md
+++ b/docs/mine/lotus/message-pool.md
@@ -34,7 +34,7 @@ When a message is executed it consumes _gas_. The total gas consumed by a messag
 Lotus can be configured with several addresses to have more granular control over fees and limits depending on the operation and avoid head-of-line blocking, particularly for high value operations such as _WindowPoSts_. Check the [miner wallets guide](miner-wallets.md).
 :::
 
-Gas usage and fees are explained in detail in [how-filecoin-works](../../about-filecoin/how-filecoin-works.md). As an additional tip, you can use Lotus to find out about the current _BaseFee_:
+The [How Filecoin works page](../../about-filecoin/how-filecoin-works.md) explains gas-usage and fee in more detail. As an additional tip, you can use Lotus to find out about the current _BaseFee_:
 
 ```sh
 # Will print the last BaseFee in attoFIL

--- a/docs/mine/lotus/message-pool.md
+++ b/docs/mine/lotus/message-pool.md
@@ -34,20 +34,12 @@ When a message is executed it consumes _gas_. The total gas consumed by a messag
 Lotus can be configured with several addresses to have more granular control over fees and limits depending on the operation and avoid head-of-line blocking, particularly for high value operations such as _WindowPoSts_. Check the [miner wallets guide](miner-wallets.md).
 :::
 
-In the Filecoin Network, a dynamic **_BaseFee_**, measured in attoFIL/gas units, specifies how much FIL gets burned _per unit of gas consumed_ for the execution of every message based. The total amount of FIL burnt per message is, therefore, given by _BaseFee \* GasUsed_. The _BaseFee_ gets automatically updated according to the network congestion parameters (block sizes). The current value can be obtained from one of the [block explorers](../../get-started/explore-the-network.md) or by looking at the current head:
+Gas usage and fees are explained in detail in [how-filecoin-works](../../about-filecoin/how-filecoin-works.md). As an additional tip, you can use Lotus to find out about the current _BaseFee_:
 
 ```sh
 # Will print the last BaseFee in attoFIL
 lotus chain head | xargs lotus chain getblock | jq -r .ParentBaseFee
 ```
-
-Apart from the _BaseFee_, every message in the message pool has the following gas-related fields:
-
-- **_GasLimit_**: it is measured in gas units. It is a hard limit on the amount of gas that a message's execution can consume. A message consumes gas for every fundamental operation it takes (see [prices](https://github.com/filecoin-project/lotus/blob/d678fe4bfa5b4c70bcebd46cdc38aafc452b42d1/chain/vm/gas.go#L87)). Messages will fail if they run out of gas fails, at which point every modification to the state is reverted. Whether the execution is successful or not, the miner is given a reward calculated as _GasLimit \* GasPremium_.
-- **_GasPremium_**: it is measured in attoFIL/gas units. It indicates how much a miner earns as their reward for including a message. A message typically earns its miner _GasLimit \* GasPremium_ attoFIL.
-- **_GasFeeCap_**: it is measured in attoFIL/gas units. Its purpose is to establish a hard limit on the amount of FIL a message can cost its sender. A sender is guaranteed that a message will never cost them more than _GasLimit \* GasFeeCap_, not including any value that the message includes for its recipient (in terms of GasPremium). The total fee (in attoFIL/gas) for a message is _GasPremium + BaseFee_. Given that _GasPremium_ is set by the sender, _GasFeeCap_ essentially serves as a safeguard against a high, unexpected _BaseFee_.
-
-If _BaseFee + GasPremium_ is greater than the message's _GasFeeCap_, the miner's reward becomes _GasLimit \* (GasFeeCap - BaseFee)_. Note that if a message's _GasFeeCap_ is lower than the _BaseFee_, then the remainder comes from the miner (as a penalty).
 
 ## Checking for pending messages
 


### PR DESCRIPTION
Documentation on gas and fees was in the message pool guide, but this is not
information that is specific to lotus, it actually belongs to the network.

This moves information and definitions about gas and fees to the
how-filecoin-works guide. It takes in some improvements from the Gas Fees blog
post and adds some more.