### PR TITLE
Expand doc on deal-fitlering via external hooks

### DIFF
--- a/docs/mine/lotus/manage-storage-deals.md
+++ b/docs/mine/lotus/manage-storage-deals.md
@@ -96,23 +96,9 @@ The list displays:
 - The wallet address of client that submitted it.
 - The size and the duration in epochs (30 seconds per epoch).
 
-## Using filters to limit deals
+## Blocking storage deals by PieceCID
 
-Lotus Miners may want to customize the conditions that deals are accepted. This can be achieved by providing an external program or script in the `Filter` option of the `[Dealmaking]` [section in the configuration](miner-configuration.md).
-
-If the external program exists with a **success status code (0)**, the deal is accepted. Otherwise, the deal gets rejected.
-
-For example, the following filter only accepts deals from clients with specific addresses:
-
-```sh
-Filter = "jq -e '.Proposal.Client == \"t1nslxql4pck5pq7hddlzym3orxlx35wkepzjkm3i\" or .Proposal.Client == \"t1stghxhdp2w53dym2nz2jtbpk6ccd4l2lxgmezlq\" or .Proposal.Client == \"t1mcr5xkgv4jdl3rnz77outn6xbmygb55vdejgbfi\" or .Proposal.Client == \"t1qiqdbbmrdalbntnuapriirduvxu5ltsc5mhy7si\" '"
-```
-
-[This Perl script](https://gist.github.com/ribasushi/53b7383aeb6e6f9b030210f4d64351d5/9bd6e898f94d20b50e7c7586dc8b8f3a45dab07c#file-dealfilter-pl) is another example. It lets the miner deny specific clients, and to only accept deals that are set to start soon.
-
-## Blocking content
-
-The Lotus Miner provides tooling to import a DataCID-blocklist:
+The Lotus Miner provides internal tooling to import a PieceCID-blocklist:
 
 ```sh
 lotus-miner storage-deals set-blocklist blocklist-file.txt

--- a/docs/mine/lotus/miner-configuration.md
+++ b/docs/mine/lotus/miner-configuration.md
@@ -103,7 +103,7 @@ This section controls parameters for making storage and retrieval deals:
 The final value of `ExpectedSealDuration` should equal `(TIME_TO_SEAL_A_SECTOR + WaitDealsDelay) * 1.5`. This equation ensures that the miner does not commit to having the sector sealed too soon.
 :::
 
-## Using filters for fine-grained Storage and Retrieval Deal acceptance
+## Using filters for fine-grained storage and retrieval deal acceptance
 
 In certain situations it is desirable to have more precise and dynamic control over a combination of deal parameters like for example:
 - cryptographic identity of client
@@ -111,16 +111,23 @@ In certain situations it is desirable to have more precise and dynamic control o
 - content
 - etc.
 
-Lotus provides two IPC hooks allowing you to name a command to execute for
-every deal before it is accepted by the miner: `Filter` for storage deals and `RetrievalFilter` for retrieval deals. The executed command receives a JSON representation of the deal parameters on standard input, and is expected to
-either exit with 0 (success, proceed with deal) or with non-0 (failure, reject deal).
+Lotus provides two IPC hooks allowing you to name a command to execute for every deal before the miner accepts it: 
 
-- The most trivial filter rejecting any retrieval deal would be something like:
-`RetrievalFilter = "/bin/false"`
+- `Filter` for storage deals.
+- `RetrievalFilter` for retrieval deals. 
 
-- [This Perl script](https://gist.github.com/ribasushi/53b7383aeb6e6f9b030210f4d64351d5/9bd6e898f94d20b50e7c7586dc8b8f3a45dab07c#file-dealfilter-pl) is another example. It lets the miner deny specific clients, and to only accept deals that are set to start relatively soon.
+The executed command receives a JSON representation of the deal parameters on standard input, and upon completion its exit code is interpreted as: 
 
-- You can also use a third party content policy framework like `bitscreen` by Murmuration Labs:
+- `0`: success, proceed with the deal. 
+- `non-0`: failure, reject the deal.
+
+The most trivial filter rejecting any retrieval deal would be something like:
+`RetrievalFilter = "/bin/false"`. `/bin/false` is binary that immediately exits with a code of `1`.
+
+[This Perl script](https://gist.github.com/ribasushi/53b7383aeb6e6f9b030210f4d64351d5/9bd6e898f94d20b50e7c7586dc8b8f3a45dab07c#file-dealfilter-pl) lets the miner deny specific clients and only accept deals that are set to start relatively soon.
+
+You can also use a third party content policy framework like `bitscreen` by Murmuration Labs:
+
 ```sh
 # grab filter program
 go get -u -v github.com/Murmuration-Labs/bitscreen
@@ -128,7 +135,6 @@ go get -u -v github.com/Murmuration-Labs/bitscreen
 # add it to both filters
 Filter = "/path/to/go/bin/bitscreen"
 RetrievalFilter = "/path/to/go/bin/bitscreen"
-```
 
 
 ## Sealing section

--- a/docs/mine/lotus/miner-configuration.md
+++ b/docs/mine/lotus/miner-configuration.md
@@ -120,8 +120,7 @@ either exit with 0 (success, proceed with deal) or with non-0 (failure, reject d
 
 - [This Perl script](https://gist.github.com/ribasushi/53b7383aeb6e6f9b030210f4d64351d5/9bd6e898f94d20b50e7c7586dc8b8f3a45dab07c#file-dealfilter-pl) is another example. It lets the miner deny specific clients, and to only accept deals that are set to start relatively soon.
 
-- You could also rely on a third party filtering framework like `bitscreen`
-by Murmuration Labs:
+- You can also use a third party content policy framework like `bitscreen` by Murmuration Labs:
 ```sh
 # grab filter program
 go get -u -v github.com/Murmuration-Labs/bitscreen

--- a/docs/mine/lotus/miner-configuration.md
+++ b/docs/mine/lotus/miner-configuration.md
@@ -89,8 +89,12 @@ This section controls parameters for making storage and retrieval deals:
   PieceCidBlocklist = []
   # How long the sealing process for a sector should take (see below)
   ExpectedSealDuration = "12h0m0s"
-  # A filter expression to only accept very specific deals (see below)
-  Filter = ""
+
+  # A command used for fine-grained evaluation of storage deals (see below)
+  Filter = "/absolute/path/to/storage_filter_program"
+
+  # A command used for fine-grained evaluation of retrieval deals (see below)
+  RetrievalFilter = "/absolute/path/to/retrieval_filter_program"
 ```
 
 `ExpectedSealDuration` is an estimate of how long sealing will take, and is used to reject deals whose start epoch might be earlier than the expected completion of sealing. It can be estimated by [benchmarking](benchmarks.md) or by [pledging a sector](sector-pledging.md).
@@ -99,9 +103,34 @@ This section controls parameters for making storage and retrieval deals:
 The final value of `ExpectedSealDuration` should equal `(TIME_TO_SEAL_A_SECTOR + WaitDealsDelay) * 1.5`. This equation ensures that the miner does not commit to having the sector sealed too soon.
 :::
 
-To filter deals based on certain parameters, modify the `Filter` param. This param should be a shell command that will be run when processing a deal proposal. Deals are accepted if the Filter's exit code is 0. For any other exit code, deals will be rejected.
+## Using filters for fine-grained Storage and Retrieval Deal acceptance
 
-For information on how to enable and disable deals and examples on filter usage see the [Storage Deals guide](manage-storage-deals.md).
+In certain situations it is desirable to have more precise and dynamic control over a combination of deal parameters like for example:
+- cryptographic identity of client
+- time of day / resource utilization
+- content
+- etc.
+
+Lotus provides two IPC hooks allowing you to name a command to execute for
+every deal before it is accepted by the miner: `Filter` for storage deals and `RetrievalFilter` for retrieval deals. The executed command receives a JSON representation of the deal parameters on standard input, and is expected to
+either exit with 0 (success, proceed with deal) or with non-0 (failure, reject deal).
+
+- The most trivial filter rejecting any retrieval deal would be something like:
+`RetrievalFilter = "/bin/false"`
+
+- [This Perl script](https://gist.github.com/ribasushi/53b7383aeb6e6f9b030210f4d64351d5/9bd6e898f94d20b50e7c7586dc8b8f3a45dab07c#file-dealfilter-pl) is another example. It lets the miner deny specific clients, and to only accept deals that are set to start relatively soon.
+
+- You could also rely on a third party filtering framework like `bitscreen`
+by Murmuration Labs:
+```sh
+# grab filter program
+go get -u -v github.com/Murmuration-Labs/bitscreen
+
+# add it to both filters
+Filter = "/path/to/go/bin/bitscreen"
+RetrievalFilter = "/path/to/go/bin/bitscreen"
+```
+
 
 ## Sealing section
 

--- a/docs/mine/lotus/miner-configuration.md
+++ b/docs/mine/lotus/miner-configuration.md
@@ -105,11 +105,7 @@ The final value of `ExpectedSealDuration` should equal `(TIME_TO_SEAL_A_SECTOR +
 
 ## Using filters for fine-grained storage and retrieval deal acceptance
 
-In certain situations it is desirable to have more precise and dynamic control over a combination of deal parameters like for example:
-- cryptographic identity of client
-- time of day / resource utilization
-- content
-- etc.
+Your use-case might demand very precise and dynamic control over a combination of deal parameters.
 
 Lotus provides two IPC hooks allowing you to name a command to execute for every deal before the miner accepts it: 
 


### PR DESCRIPTION
@johnnymatthews @jnthnvctr so... this is ready for review but is also somewhat of a draft:
- I scaled back the lean on "storage-deal filtering" and extended things in the general doc on filtering.
- The functionality added back in https://github.com/filecoin-project/lotus/pull/2069 was mid-documented ( it only works with PieceCIDs ) and I'd argue we need to go further and remove it entirely: it is of little utility :( 
- I would personally find examples of the JSON that is being fed to the programs **very** useful, but am not sure where it would fit nicely. Examples of both can be seen here: https://github.com/Murmuration-Labs/bitscreen/tree/45a84483c5a369c6fe6db90723aee11909b33ab4/testdata