### PR TITLE
Fixing typo that should have FIL not attoFIL as units

### DIFF
--- a/docs/mine/lotus/manage-storage-deals.md
+++ b/docs/mine/lotus/manage-storage-deals.md
@@ -65,7 +65,7 @@ lotus-miner storage-deals set-ask \
   --max-piece-size 32GB
 ```
 
-The above command sets the price for deals to `0.0000001 attoFIL` (`100 nanoFIL`) per GiB, per epoch. This means, a client will have to pay `100 nanoFIL` every 30 seconds for each GiB stored. If the client wants 5GiB stored over the course of a week, the total price will be: `5GiB * 100nanoFIL/GiB_Epoch * 20160 Epochs = 10080 microFIL`.
+The above command sets the price for deals to `0.0000001 FIL` (`100 nanoFIL`) per GiB, per epoch. This means, a client will have to pay `100 nanoFIL` every 30 seconds for each GiB stored. If the client wants 5GiB stored over the course of a week, the total price will be: `5GiB * 100nanoFIL/GiB_Epoch * 20160 Epochs = 10080 microFIL`.
 
 The command also serves to set the minimum and maximum deal sizes. Be sure to check `lotus-miner storage-deals set-ask --help` to see all options.
 


### PR DESCRIPTION
Confirming that storage-deal prices are in FIL not attoFIL

<img width="845" alt="Screen Shot 2020-11-18 at 3 17 03 PM" src="https://user-images.githubusercontent.com/1017762/99541538-3a5c2680-29b1-11eb-9e6d-f0abb9d2c45e.png">
