### PR TITLE
installation: suggest CGO_CFLAGS for "older" CPUs

### DIFF
--- a/docs/get-started/lotus/installation.md
+++ b/docs/get-started/lotus/installation.md
@@ -119,7 +119,7 @@ Once all the dependencies are installed, you can build and install the Lotus sui
 
    See the [Native Filecoin FFI section](#native-filecoin-ffi) for more details about this process.
 
-   If you are building Lotus 0.7.1 or older and have an Intel or AMD processor without the ADX instruction set, add the `CGO_CFLAGS` environment variable:
+   Some older Intel and AMD processors without the ADX instruction support may panic with illegal instruction errors. To fix this, add the `CGO_CFLAGS` environment variable:
 
    ```sh
    export CGO_CFLAGS_ALLOW="-D__BLST_PORTABLE__"


### PR DESCRIPTION
Disregard the Lotus version. I am not sure this has been fixed, but I heard a recent report that suggests it hasn't. Users on Intel should preferably use this then.