### PR TITLE
Install wget in Debian

### DIFF
--- a/docs/get-started/lotus/installation.md
+++ b/docs/get-started/lotus/installation.md
@@ -41,7 +41,7 @@ sudo pacman -Syu opencl-icd-loader gcc git bzr jq pkg-config opencl-icd-loader o
 Ubuntu/Debian:
 
 ```bash
-sudo apt install mesa-opencl-icd ocl-icd-opencl-dev gcc git bzr jq pkg-config curl clang build-essential hwloc libhwloc-dev -y && sudo apt upgrade -y
+sudo apt install mesa-opencl-icd ocl-icd-opencl-dev gcc git bzr jq pkg-config curl clang build-essential hwloc libhwloc-dev wget -y && sudo apt upgrade -y
 ```
 
 Fedora:


### PR DESCRIPTION
Ensures `wget` is installed as dependency on Debian. It is required for Go install and is not installed by default.