### PR TITLE
howto reduce mpool pendig --local output

### DIFF
--- a/docs/mine/lotus/message-pool.md
+++ b/docs/mine/lotus/message-pool.md
@@ -53,6 +53,12 @@ lotus mpool pending --local
 
 For each message you will be able to see key information like the _GasLimit_, the _GasFeeCap_ and the _GasPremium_ values, explained above.
 
+To reduce the output to the messages key values you can use:
+
+ ```sh
+lotus mpool pending --local | grep "Nonce" -A5
+```
+
 In order to avoid messages from staying long periods in the pool when they are sent, it is possible to adjust the [Lotus Miner fees in the configuration](miner-configuration.md) and use [additional control addresses for _WindowPoSts_](miner-addresses.md). Existing messages can be replaced at any time with the procedure explained below.
 
 ## Replacing messages in the pool


### PR DESCRIPTION
the output of `lotus mpool pending --local` is extensive and most of a messages values are not relevant for daily operation. 

added command to reduce the output of the command to key message values

fixes https://github.com/filecoin-project/filecoin-docs/issues/663