### PR TITLE
Remove Filfox wallet

### DIFF
--- a/docs/get-started/README.md
+++ b/docs/get-started/README.md
@@ -46,7 +46,6 @@ The Filecoin Network is made by miners and clients. They [make deals](../about-f
 | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | [Lotus](lotus/README.md)                         | Lotus can manage bls, sec1p256k1 wallets and supports [Ledger integration](lotus/ledger.md).                                                                                               |
 | [Glif wallet](https://wallet.glif.io/?network=f) | Glif is a lightweight web interface to send and receive Filecoin with a Ledger device ([instructions](https://reading.supply/@glif/install-the-filecoin-app-on-your-ledger-device-y33vhX)). |
-| [Filfox Wallet](https://wallet.filfox.info/en)   | A web-based wallet.                                                                                                                                                                        |
 
 ### Filecoin implementations
 


### PR DESCRIPTION
A Filecoin community user in Slack tried Filfox Wallet and got their funds stuck, it doesn't look security audited and not sure why it's linked from Filfox. We can mention that there are additional wallets when the updated References page PR is merged.