### PR TITLE
Removes `text codeblocks.

### DIFF
--- a/docs/community/contribute/grammar-formatting-and-style.md
+++ b/docs/community/contribute/grammar-formatting-and-style.md
@@ -364,7 +364,7 @@ Store images in a folder called `images` within the same directory as the articl
 
 The directory structure of this article looks like this:
 
-```text
+```
 concepts/
 ├── content-addressed-data.md
 ├── images
@@ -380,7 +380,7 @@ There are no images within the `proof-of-replication.md` article, so there is no
 
 All file names are lower-case with dashes `-` between words, including image files:
 
-```text
+```
 concepts/
 ├── content-addressed-data.md
 ├── images

--- a/docs/mine/lotus/seal-workers.md
+++ b/docs/mine/lotus/seal-workers.md
@@ -169,7 +169,7 @@ taskset -c 0,1,2,3 <worker_pid | command>
 
 It is also possible to set [_CPU affinity_ with systemd](https://www.freedesktop.org/software/systemd/man/systemd-system.conf.html):
 
-```text
+```
 # workerN.service
 ...
 CPUAffinity=C1,C2... # Specify the core number that this worker will use.


### PR DESCRIPTION
Removes a few ` ```text ` blocks from markdown since `text` is not a supported syntax style.