### PR TITLE
Using skip-old-msgs fails

### DIFF
--- a/docs/get-started/lotus/chain.md
+++ b/docs/get-started/lotus/chain.md
@@ -123,7 +123,7 @@ lotus chain export --recent-stateroots=2000 <filename>
 To create a _pruned_ snapshot and only include blocks directly referenced by the exported state roots, add the `skip-old-msgs` option:
 
 ```bash
-lotus chain export --skip-old-msgs <filename>
+lotus chain export --recent-stateroots=2000 --skip-old-msgs <filename>
 ```
 
 ## Restoring a custom snapshot


### PR DESCRIPTION
When following the documentation the command below fails.

`lotus chain export --skip-old-msgs <filename>`

with the error

`ERROR: must pass recent stateroots along with skip-old-msgs`

This patch updates the example to also include the needed `-recent-stateroots` option.