### PR TITLE
Add a page for Lotus lite-nodes.

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -157,6 +157,7 @@ module.exports = {
               sidebarDepth: 2,
               collapsable: true,
               children: [
+                ['lotus/lotus-lite', 'Lotus lite'],
                 ['lotus/enable-remote-api-access', 'Enable remote API access'],
                 ['lotus/api-tokens', 'API tokens'],
                 ['lotus/api-client-libraries', 'API client libraries'],

--- a/docs/build/lotus/lotus-lite.md
+++ b/docs/build/lotus/lotus-lite.md
@@ -43,6 +43,7 @@ If you have access to the full-node you're using, you need to make some minor mo
     Which permissions you choose will depend on your use-case. Take a look at the [API tokens section to find out more →](https://docs.filecoin.io/build/lotus/api-tokens/#obtaining-tokens)
 
 1. Send this API token to your lite-node, or to whoever will be the administator for the lite-node.
+1. If you have the `lotus daemon` running, stop it and start it again. This forces Lotus to open the API port we just set.
 
 Next up you'll create the Lotus executable on your lite-node and running it in _lite_ mode!
 

--- a/docs/build/lotus/lotus-lite.md
+++ b/docs/build/lotus/lotus-lite.md
@@ -19,9 +19,9 @@ Before we get started, let's just go over the terms we'll use in this guide:
 
 To spin up a Lotus lite-node, you will need:
 
-1. A [Lotus full-node](../../get-started/lotus). For best results, make sure that this node is fully synced. 
+1. A [Lotus full-node](../../get-started/lotus/installation). For best results, make sure that this node is fully synced. 
 2. A computer with at least 2GB RAM and a dual-core CPU to act as the Lotus lite-node. This can be your local machine. This computer must have Rust and Go 1.15 or higher installed.
-3. You must have [all the software dependencies required](../../get-started/lotus/installation##software-dependencies) to build Lotus.
+3. You must have [all the software dependencies required](../../get-started/lotus/installation#software-dependencies) to build Lotus.
 
 ## Full-node preparation
 

--- a/docs/build/lotus/lotus-lite.md
+++ b/docs/build/lotus/lotus-lite.md
@@ -15,7 +15,7 @@ Before we get started, let's just go over the terms we'll use in this guide:
 | Full-node | A Lotus node that contains all the blockchain data of the Filecoin network. |
 | Lite-node | A Lotus node that does not contain any of the blockchain data of the Filecoin network. Lite-nodes rely on access to a full-node in order to run. |
 
-## Prerequsites
+## Prerequisites
 
 To spin up a Lotus lite-node, you will need:
 
@@ -25,7 +25,7 @@ To spin up a Lotus lite-node, you will need:
 
 ## Full-node preparation
 
-If you have access to the full-node you're using, you need to make some minor modifications to it's configuration.
+If you have access to the full-node you're using, you need to make some minor modifications to its configuration.
 
 1. On your full-node open `~/.lotus/config` and:
 
@@ -47,10 +47,10 @@ If you have access to the full-node you're using, you need to make some minor mo
 
     Which permissions you choose will depend on your use-case. Take a look at the [API tokens section to find out more →](https://docs.filecoin.io/build/lotus/api-tokens/#obtaining-tokens)
 
-1. Send this API token to your lite-node, or to whoever will be the administator for the lite-node.
+1. Send this API token to your lite-node or to whoever will be the administrator for the lite-node.
 1. If you have the `lotus daemon` running, stop it and start it again. This forces Lotus to open the API port we just set.
 
-Next up you'll create the Lotus executable on your lite-node and running it in _lite_ mode!
+Next up, you'll create the Lotus executable on your lite-node and running it in _lite_ mode!
 
 ## Create the Lotus executable 
 
@@ -65,13 +65,13 @@ You need to create the Lotus executable to run your lite-node with. This process
     sudo make install
     ```
 
-If you run into errors here, it may be because you don't have all the Lotus dependencies installed. Take a quick look at the [Lotus Getting Started guide](/get-started/lotus/installation/#software-dependencies) and double check that you have all the dependencies installed, along with Golang and Rust.
+If you run into errors here, it may be because you don't have all the Lotus dependencies installed. Take a quick look at the [Lotus Getting Started guide](/get-started/lotus/installation/#software-dependencies) and double-check that you have all the dependencies installed, along with Golang and Rust.
 
 ## Start the lite-node
 
 You've got the Lotus executables ready to go, and you have access to a Lotus full-node. All that's left is connecting your Lotus lite-node to the full-node!
 
-1. On the lite-node, create an environment variable called `FULLNODE_API_INFO` and give it the following value while calling `lotus daemon --lite`. Make sure to replace `API_TOKEN` with the token you got from the full-node, and `YOUR_FULL_NODE_IP_ADDRESS` with the IP address of your full-node:
+1. On the lite-node, create an environment variable called `FULLNODE_API_INFO` and give it the following value while calling `lotus daemon --lite`. Make sure to replace `API_TOKEN` with the token you got from the full-node and `YOUR_FULL_NODE_IP_ADDRESS` with the IP address of your full-node:
 
     ```shell
     FULLNODE_API_INFO=API_TOKEN/ip4/YOUR_FULL_NODE_IP_ADDRESS/tcp/1234 lotus daemon --lite
@@ -80,7 +80,7 @@ You've got the Lotus executables ready to go, and you have access to a Lotus ful
     > ...
     ```
 
-    If you don't have an `API_TOKEN`, you can run the above command without one, and just gain read-only access to the full-node:
+    If you don't have an `API_TOKEN`, you can run the above command without one and just gain read-only access to the full-node:
 
     ```shell
     FULLNODE_API_INFO=/ip4/YOUR_FULL_NODE_IP_ADDRESS/tcp/1234 lotus daemon --lite
@@ -94,7 +94,7 @@ You've got the Lotus executables ready to go, and you have access to a Lotus ful
     > 100 FIL
     ```
 
-A lite-node is limited in what it can do and is designed to only perform message signing and transactional operations. Lite-nodes cannot seal data or query the chain directly. All chain requests go through the attached full-node. If for whatever reason, the full-node goes offline, any lite-nodes connected to it will also go offline.
+A lite-node is limited in what it can do and is designed to only perform message signing and transactional operations. Lite-nodes cannot seal data or query the chain directly. All chain requests go through the attached full-node. If, for whatever reason, the full-node goes offline, any lite-nodes connected to it will also go offline.
 
 ### Access and permissions 
 

--- a/docs/build/lotus/lotus-lite.md
+++ b/docs/build/lotus/lotus-lite.md
@@ -1,58 +1,93 @@
 ---
 title: Lite node 
-description: "A Lotus lite-node is a stripped down version of a Lotus full-node capable of running on lower-end hardware. Lotus lite-nodes do not contain any chain-data and can only perform message signing and deal transactions. However, they are very quick to spin up, and process transactions in parallel with other Lotus lite-nodes."
+description: "A Lotus lite-node is a stripped down version of a Lotus full-node capable of running on lower-end hardware. Lotus lite-nodes do not contain any chain-data and can only perform message signing and deal transactions. However, they are very quick to spin up and can process transactions in parallel with other Lotus lite-nodes."
 ---
 
 # Lite node 
 
-A Lotus lite-node is a stripped-down version of a Lotus full-node capable of running on lower-end hardware. Lotus lite-nodes do not contain any chain-data and can only perform message signing and deal transactions. However, they are very quick to spin up and process transactions in parallel with other Lotus lite-nodes.
+A Lotus lite-node is a stripped-down version of a Lotus full-node capable of running on lower-end hardware. Lotus lite-nodes do not contain any chain-data and can only perform message signing and deal transactions. However, they are very quick to spin up and can process transactions in parallel with other Lotus lite-nodes.
 
-## Install
+Before we get started, let's just go over the terms we'll use in this guide:
 
-### Prerequsites
+| Term | Description |
+| --- | --- |
+| Lotus | The main Filecoin implementation, written in Golang. |
+| Full-node | A Lotus node that contains all the blockchain data of the Filecoin network. |
+| Lite-node | A Lotus node that does not contain any of the blockchain data of the Filecoin network. Lite-nodes rely on access to a full-node in order to run. |
+
+## Prerequsites
 
 To spin up a Lotus lite-node, you will need:
 
 1. A [Lotus full-node](../../get-started/lotus). For best results, make sure that this node is fully synced. 
 2. A computer with at least 2GB RAM and a dual-core CPU to act as the Lotus lite-node. This can be your local machine. This computer must have Rust and Go 1.15 or higher installed.
 
-### Steps
+## Full-node preparation
 
-1. On the full-node open `~/.lotus/config` and edit line 3 to read:
+If you have access to the full-node you're using, you need to make some minor modifications to it's configuration.
 
-```
-ListenAddress = "/ip4/0.0.0.0/tcp/28001/http"
-```
+1. On your full-node open `~/.lotus/config` and edit line 3 to read:
 
-2. On your lite-node clone the [Lotus GitHub repository](https://github.com/filecoin-project/lotus) and create the binary, but do not run anything yet:
+    ```toml
+    ListenAddress = "/ip4/0.0.0.0/tcp/28001/http"
+    ```
 
-```
-git clone <https://github.com/filecoin-project/lotus>
-cd lotus
-make clean all
-sudo make install
-```
+1. Create an API token for your lite-node to use:
 
-3. On the lite-node, create an environment variable called `FULLNODE_API_INFO` and give it the following value while calling `lotus daemon --lite`:
+    ```shell
+    # lotus auth create-token --perm <read,write,sign,admin>
+    lotus auth create-token --perm write
+    ```
 
-```
-$FULLNODE_API_INFO=/ip4/YOUR_FULL_NODE_IP_ADDRESS/tcp/28001 lotus daemon --lite
+    Which permissions you choose will depend on your use-case. Take a look at the [API tokens section to find out more →](https://docs.filecoin.io/build/lotus/api-tokens/#obtaining-tokens)
 
-> 2021-03-02T23:59:50.609Z        INFO    main    lotus/daemon.go:201     lotus repo: /root/.lotus
-> ...
-```
+1. Send this API token to your lite-node, or to whoever will be the administator for the lite-node.
 
-Make sure to replace `YOUR_FULL_NODE_IP_ADDRESS` with the IP address of your full-node.
+Next up you'll create the Lotus executable on your lite-node and running it in _lite_ mode!
 
-4. You can now interact with your Lotus lite-node:
+## Create the Lotus executable 
 
-```
-lotus wallet balance f10...
+You need to create the Lotus executable to run your lite-node with. This process is the same as when creating a full-node.
 
-> 100 FIL
-```
+1. On your lite-node clone the [Lotus GitHub repository](https://github.com/filecoin-project/lotus) and create the executable, but do not run anything yet:
+
+    ```shell
+    git clone https://github.com/filecoin-project/lotus
+    cd lotus
+    make clean all
+    sudo make install
+    ```
+
+    If you run into errors here, it may be because you don't have all the Lotus dependencies installed. Take a quick look at the [Lotus Getting Started guide](/get-started/lotus/installation/#software-dependencies) and double check that you have all the dependencies installed, along with Golang and Rust.
+
+## Start the lite-node
+
+You've got the Lotus executables ready to go, and you have access to a Lotus full-node. All that's left is connecting your Lotus lite-node to the full-node!
+
+1. On the lite-node, create an environment variable called `FULLNODE_API_INFO` and give it the following value while calling `lotus daemon --lite`:
+
+    ```shell
+    FULLNODE_API_INFO=/ip4/YOUR_FULL_NODE_IP_ADDRESS/tcp/28001 lotus daemon --lite
+
+    > 2021-03-02T23:59:50.609Z        INFO    main    lotus/daemon.go:201     lotus repo: /root/.lotus
+    > ...
+    ```
+
+  Make sure to replace `YOUR_FULL_NODE_IP_ADDRESS` with the IP address of your full-node.
+
+1. You can now interact with your Lotus lite-node:
+
+    ```
+    lotus wallet balance f10...
+
+    > 100 FIL
+    ```
 
 A lite-node is limited in what it can do and is designed to only perform message signing and transactional operations. Lite-nodes cannot seal data or query the chain directly. All chain requests go through the attached full-node. If for whatever reason, the full-node goes offline, any lite-nodes connected to it will also go offline.
+
+### Access and permissions 
+
+Setting up a Lotus lite-node without using an [API token from a full-node](https://docs.filecoin.io/build/lotus/api-tokens/) results in the lite-node having read-only access to the full-node. While read-only access should be fine for most use-cases, there are situations where you need write access to the full-node. 
 
 ## Use cases 
 

--- a/docs/build/lotus/lotus-lite.md
+++ b/docs/build/lotus/lotus-lite.md
@@ -27,11 +27,16 @@ To spin up a Lotus lite-node, you will need:
 
 If you have access to the full-node you're using, you need to make some minor modifications to it's configuration.
 
-1. On your full-node open `~/.lotus/config` and edit line 3 to read:
+1. On your full-node open `~/.lotus/config` and:
+
+    a. Uncommend line 3.
+    a. Change `127.0.0.1` to `0.0.0.0`.
 
     ```toml
     ListenAddress = "/ip4/0.0.0.0/tcp/1234/http"
     ```
+    
+    Save and exit the file.
 
 1. Create an API token for your lite-node to use:
 

--- a/docs/build/lotus/lotus-lite.md
+++ b/docs/build/lotus/lotus-lite.md
@@ -1,0 +1,70 @@
+---
+title: Lite node 
+description: "A Lotus lite-node is a stripped down version of a Lotus full-node capable of running on lower-end hardware. Lotus lite-nodes do not contain any chain-data and can only perform message signing and deal transactions. However, they are very quick to spin up, and process transactions in parallel with other Lotus lite-nodes."
+---
+
+# Lite node 
+
+A Lotus lite-node is a stripped-down version of a Lotus full-node capable of running on lower-end hardware. Lotus lite-nodes do not contain any chain-data and can only perform message signing and deal transactions. However, they are very quick to spin up and process transactions in parallel with other Lotus lite-nodes.
+
+## Install
+
+### Prerequsites
+
+To spin up a Lotus lite-node, you will need:
+
+1. A [Lotus full-node](../../get-started/lotus). For best results, make sure that this node is fully synced. 
+2. A computer with at least 2GB RAM and a dual-core CPU to act as the Lotus lite-node. This can be your local machine. This computer must have Rust and Go 1.15 or higher installed.
+
+### Steps
+
+1. On the full-node open `~/.lotus/config` and edit line 3 to read:
+
+```
+ListenAddress = "/ip4/0.0.0.0/tcp/28001/http"
+```
+
+2. On your lite-node clone the [Lotus GitHub repository](https://github.com/filecoin-project/lotus) and create the binary, but do not run anything yet:
+
+```
+git clone <https://github.com/filecoin-project/lotus>
+cd lotus
+make clean all
+sudo make install
+```
+
+3. On the lite-node, create an environment variable called `FULLNODE_API_INFO` and give it the following value while calling `lotus daemon --lite`:
+
+```
+$FULLNODE_API_INFO=/ip4/YOUR_FULL_NODE_IP_ADDRESS/tcp/28001 lotus daemon --lite
+
+> 2021-03-02T23:59:50.609Z        INFO    main    lotus/daemon.go:201     lotus repo: /root/.lotus
+> ...
+```
+
+Make sure to replace `YOUR_FULL_NODE_IP_ADDRESS` with the IP address of your full-node.
+
+4. You can now interact with your Lotus lite-node:
+
+```
+lotus wallet balance f10...
+
+> 100 FIL
+```
+
+A lite-node is limited in what it can do and is designed to only perform message signing and transactional operations. Lite-nodes cannot seal data or query the chain directly. All chain requests go through the attached full-node. If for whatever reason, the full-node goes offline, any lite-nodes connected to it will also go offline.
+
+## Use cases 
+
+A Lotus lite-node can perform transaction-based functions like creating the transaction, proposing deals, signing messages, etc. They do not have any chain data themselves and rely on a full-node for chain data completely. Lotus lite-nodes are completely useless on their own.
+
+One use-case is a service that needs to sign multiple messages a minute, such as an exchange. In this case, the service could have multiple lite-nodes specifically to sign and deal with transactional computation, while a single full-node maintains the chain data.
+
+Another scenario is an organization with a lot of data they want to store on Filecoin but no resources to run a full-node. They could create a Lotus lite-node to create deals with a full-node that they trust, and then once a miner has been found, the lite-node can transfer the data to the miner.
+
+## Benefits and drawbacks 
+
+Since Lotus lite-nodes do not need to sync any chain data, they're able to spin up quickly. Due to their minimal hardware requirements, it's possible to spin up multiple lite-nodes with quite a small footprint. A project can horizontally expand or shrink its processing power by adding or removing Lotus lite-nodes whenever necessary.
+
+However, lite-nodes come with some significant drawbacks. While there are some functions that a lite-node can perform without access to a full-node, all transactions and processes that require access to chain-data must be routed through a Lotus full-node. 
+

--- a/docs/build/lotus/lotus-lite.md
+++ b/docs/build/lotus/lotus-lite.md
@@ -30,7 +30,7 @@ If you have access to the full-node you're using, you need to make some minor mo
 1. On your full-node open `~/.lotus/config` and edit line 3 to read:
 
     ```toml
-    ListenAddress = "/ip4/0.0.0.0/tcp/28001/http"
+    ListenAddress = "/ip4/0.0.0.0/tcp/1234/http"
     ```
 
 1. Create an API token for your lite-node to use:
@@ -68,7 +68,7 @@ You've got the Lotus executables ready to go, and you have access to a Lotus ful
 1. On the lite-node, create an environment variable called `FULLNODE_API_INFO` and give it the following value while calling `lotus daemon --lite`. Make sure to replace `API_TOKEN` with the token you got from the full-node, and `YOUR_FULL_NODE_IP_ADDRESS` with the IP address of your full-node:
 
     ```shell
-    FULLNODE_API_INFO=API_TOKEN/ip4/YOUR_FULL_NODE_IP_ADDRESS/tcp/28001 lotus daemon --lite
+    FULLNODE_API_INFO=API_TOKEN/ip4/YOUR_FULL_NODE_IP_ADDRESS/tcp/1234 lotus daemon --lite
 
     > 2021-03-02T23:59:50.609Z        INFO    main    lotus/daemon.go:201     lotus repo: /root/.lotus
     > ...
@@ -77,7 +77,7 @@ You've got the Lotus executables ready to go, and you have access to a Lotus ful
     If you don't have an `API_TOKEN`, you can run the above command without one, and just gain read-only access to the full-node:
 
     ```shell
-    FULLNODE_API_INFO=/ip4/YOUR_FULL_NODE_IP_ADDRESS/tcp/28001 lotus daemon --lite
+    FULLNODE_API_INFO=/ip4/YOUR_FULL_NODE_IP_ADDRESS/tcp/1234 lotus daemon --lite
     ```
 
 1. You can now interact with your Lotus lite-node:

--- a/docs/build/lotus/lotus-lite.md
+++ b/docs/build/lotus/lotus-lite.md
@@ -45,7 +45,7 @@ If you have access to the full-node you're using, you need to make some minor mo
     lotus auth create-token --perm write
     ```
 
-    Which permissions you choose will depend on your use-case. Take a look at the [API tokens section to find out more →](https://docs.filecoin.io/build/lotus/api-tokens/#obtaining-tokens)
+    Which permissions you choose will depend on your use-case. Take a look at the [API tokens section to find out more →](./api-tokens/#obtaining-tokens)
 
 1. Send this API token to your lite-node or to whoever will be the administrator for the lite-node.
 1. If you have the `lotus daemon` running, stop it and start it again. This forces Lotus to open the API port we just set.
@@ -98,7 +98,7 @@ A lite-node is limited in what it can do and is designed to only perform message
 
 ### Access and permissions 
 
-Setting up a Lotus lite-node without using an [API token from a full-node](https://docs.filecoin.io/build/lotus/api-tokens/) results in the lite-node having read-only access to the full-node. While read-only access should be fine for most use-cases, there are situations where you need write access to the full-node. 
+Setting up a Lotus lite-node without using an [API token from a full-node](./api-tokens/) results in the lite-node having read-only access to the full-node. While read-only access should be fine for most use-cases, there are situations where you need write access to the full-node. 
 
 ## Use cases 
 

--- a/docs/build/lotus/lotus-lite.md
+++ b/docs/build/lotus/lotus-lite.md
@@ -65,7 +65,7 @@ You need to create the Lotus executable to run your lite-node with. This process
     sudo make install
     ```
 
-If you run into errors here, it may be because you don't have all the Lotus dependencies installed. Take a quick look at the [Lotus Getting Started guide](/get-started/lotus/installation/#software-dependencies) and double-check that you have all the dependencies installed, along with Golang and Rust.
+If you run into errors here, it may be because you don't have all the Lotus dependencies installed. Take a quick look at the [Lotus Getting Started guide](../../get-started/lotus/installation/#software-dependencies) and double-check that you have all the dependencies installed, along with Golang and Rust.
 
 ## Start the lite-node
 

--- a/docs/build/lotus/lotus-lite.md
+++ b/docs/build/lotus/lotus-lite.md
@@ -65,13 +65,19 @@ If you run into errors here, it may be because you don't have all the Lotus depe
 
 You've got the Lotus executables ready to go, and you have access to a Lotus full-node. All that's left is connecting your Lotus lite-node to the full-node!
 
-1. On the lite-node, create an environment variable called `FULLNODE_API_INFO` and give it the following value while calling `lotus daemon --lite`. Make sure to replace `YOUR_FULL_NODE_IP_ADDRESS` with the IP address of your full-node:
+1. On the lite-node, create an environment variable called `FULLNODE_API_INFO` and give it the following value while calling `lotus daemon --lite`. Make sure to replace `API_TOKEN` with the token you got from the full-node, and `YOUR_FULL_NODE_IP_ADDRESS` with the IP address of your full-node:
 
     ```shell
-    FULLNODE_API_INFO=/ip4/YOUR_FULL_NODE_IP_ADDRESS/tcp/28001 lotus daemon --lite
+    FULLNODE_API_INFO=API_TOKEN/ip4/YOUR_FULL_NODE_IP_ADDRESS/tcp/28001 lotus daemon --lite
 
     > 2021-03-02T23:59:50.609Z        INFO    main    lotus/daemon.go:201     lotus repo: /root/.lotus
     > ...
+    ```
+
+    If you don't have an `API_TOKEN`, you can run the above command without one, and just gain read-only access to the full-node:
+
+    ```shell
+    FULLNODE_API_INFO=/ip4/YOUR_FULL_NODE_IP_ADDRESS/tcp/28001 lotus daemon --lite
     ```
 
 1. You can now interact with your Lotus lite-node:

--- a/docs/build/lotus/lotus-lite.md
+++ b/docs/build/lotus/lotus-lite.md
@@ -50,13 +50,6 @@ Next up you'll create the Lotus executable on your lite-node and running it in _
 
 You need to create the Lotus executable to run your lite-node with. This process is the same as when creating a full-node.
 
-```
-git clone https://github.com/filecoin-project/lotus
-cd lotus
-make clean all
-sudo make install
-```
-
 1. On your lite-node clone the [Lotus GitHub repository](https://github.com/filecoin-project/lotus) and create the executable, but do not run anything yet:
 
     ```shell
@@ -66,13 +59,13 @@ sudo make install
     sudo make install
     ```
 
-    If you run into errors here, it may be because you don't have all the Lotus dependencies installed. Take a quick look at the [Lotus Getting Started guide](/get-started/lotus/installation/#software-dependencies) and double check that you have all the dependencies installed, along with Golang and Rust.
+If you run into errors here, it may be because you don't have all the Lotus dependencies installed. Take a quick look at the [Lotus Getting Started guide](/get-started/lotus/installation/#software-dependencies) and double check that you have all the dependencies installed, along with Golang and Rust.
 
 ## Start the lite-node
 
 You've got the Lotus executables ready to go, and you have access to a Lotus full-node. All that's left is connecting your Lotus lite-node to the full-node!
 
-1. On the lite-node, create an environment variable called `FULLNODE_API_INFO` and give it the following value while calling `lotus daemon --lite`:
+1. On the lite-node, create an environment variable called `FULLNODE_API_INFO` and give it the following value while calling `lotus daemon --lite`. Make sure to replace `YOUR_FULL_NODE_IP_ADDRESS` with the IP address of your full-node:
 
     ```shell
     FULLNODE_API_INFO=/ip4/YOUR_FULL_NODE_IP_ADDRESS/tcp/28001 lotus daemon --lite
@@ -81,11 +74,9 @@ You've got the Lotus executables ready to go, and you have access to a Lotus ful
     > ...
     ```
 
-  Make sure to replace `YOUR_FULL_NODE_IP_ADDRESS` with the IP address of your full-node.
-
 1. You can now interact with your Lotus lite-node:
 
-    ```
+    ```shell
     lotus wallet balance f10...
 
     > 100 FIL


### PR DESCRIPTION
A Lotus lite-node is a tiny version of Lotus that doesn't contain any chain-data, and relies on a full-node to process chain-related transactions. Lite-nodes are useful for performing actions that do not require access to the Filecoin chain such as deal-making and transferring files.