### PR TITLE
Note on BLS curves and big/little endianess

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Filecoin Docs
 
-**View conceptual documenation for the Filecoin project at [docs.filecoin.io](https://docs.filecoin.io/).** You may also be interested in Filecoin's [technical specifcation](https://filecoin-project.github.io/specs/) or the implementation details provided in the [lotus tutorial](https://lotu.sh).
+**View conceptual documentation for the Filecoin project at [docs.filecoin.io](https://docs.filecoin.io/).** You may also be interested in Filecoin's [technical specifcation](https://filecoin-project.github.io/specs/) or the implementation details provided in the [lotus tutorial](https://lotu.sh).
 
 This repo generates the new conceptual Filecoin documentation at [docs.filecoin.io](https://docs.filecoin.io/), building off of the work done in [VuePress](https://github.com/vuejs/vuepress) by the IPFS Docs team to create their [spiffy new IPFS docs site](https://docs-beta.ipfs.io/) (in beta).
 

--- a/docs/about-filecoin/how-filecoin-works.md
+++ b/docs/about-filecoin/how-filecoin-works.md
@@ -120,11 +120,14 @@ Robust addresses provide a safe way to reference actors before the chain state i
 
 Actor addresses provide a way to create robust addresses for actors not associated with a public key. They are the essentially random sha256 hash of the output of the account creation. The [ZH Storage Miner](https://filfox.info/en/address/f01248) has the Actor Address `f2plku564ddywnmb5b2ky7dhk4mb6uacsxuuev3pi` and the ID address `f01248`.
 
+### BLS Curve
+Filecoin uses curve bls12-381 for BLS signatures. Bls12-381 is a pair of two related curves: G1 and G2. Implementations of bls12-381 can vary based on if public keys are on G1 and signatures on G2 or vice-versa.
+
+Filecoin uses G1 for public keys and G2 for signatures as G1 allows for a smaller representation of public keys. This is the same design decision made with ETH2, but contrasts to, for instance, Zcash which has signatures on G1 and public keys on G2.
+
 ### Big vs Little Endian Keys
 
-Private keys in Filecoin use the BLS curve.
-
-Keys are stored in Little Endian on Filecoin. This is in contrast to E.g. ETH2 keys, which also use BLS but are stored as Big Endian.
+Filecoin stores and interprets private keys in little-endian order. This is in contrast to e.g. ETH2 keys, which also use bls12-381 but are stored in big-endian order.
 
 ## Additional materials
 

--- a/docs/about-filecoin/how-filecoin-works.md
+++ b/docs/about-filecoin/how-filecoin-works.md
@@ -125,9 +125,7 @@ Filecoin uses curve bls12-381 for BLS signatures. Bls12-381 is a pair of two rel
 
 Filecoin uses G1 for public keys and G2 for signatures as G1 allows for a smaller representation of public keys. This is the same design decision made with ETH2, but contrasts to, for instance, Zcash which has signatures on G1 and public keys on G2.
 
-### Big vs Little Endian Keys
-
-Filecoin stores and interprets private keys in little-endian order. This is in contrast to e.g. ETH2 keys, which also use bls12-381 but are stored in big-endian order.
+Also note that Filecoin stores and interprets private keys in little-endian order. This is in contrast to ETH2 keys, which also use bls12-381 but are stored in big-endian order.
 
 ## Additional materials
 

--- a/docs/about-filecoin/how-filecoin-works.md
+++ b/docs/about-filecoin/how-filecoin-works.md
@@ -120,6 +120,12 @@ Robust addresses provide a safe way to reference actors before the chain state i
 
 Actor addresses provide a way to create robust addresses for actors not associated with a public key. They are the essentially random sha256 hash of the output of the account creation. The [ZH Storage Miner](https://filfox.info/en/address/f01248) has the Actor Address `f2plku564ddywnmb5b2ky7dhk4mb6uacsxuuev3pi` and the ID address `f01248`.
 
+### Big vs Little Endian Keys
+
+Private keys in Filecoin use the BLS curve.
+
+Keys are stored in Little Endian on Filecoin. This is in contrast to E.g. ETH2 keys, which also use BLS but are stored as Big Endian.
+
 ## Additional materials
 
 Filecoin is built on top of [mature projects](../project/related-projects.md) like libp2p (networking, addressing, message distribution), IPLD (data formats, encoding, and content-addressed data structures), IPFS (data transfers), and multiformats (future-proof data types).


### PR DESCRIPTION
We want to document more details on the BLS curves used in Filecoin which will assist people trying to integrate with the system.

The spec mentions the BLS curves in more depth, but doesn't mention the Big / Little Endian storage anywhere, which is what tripped us up in using standard BLS libraries.

Also including a minor spelling fix for the README. 