### PR TITLE
Add pointer to running Lotus in the cloud. Publish "Running in the Cloud".

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -76,6 +76,7 @@ module.exports = {
               sidebarDepth: 2,
               collapsable: false,
               children: [
+                ['lotus/running-in-the-cloud', 'Running in the Cloud'],
                 ['lotus/installation', 'Install + Setup'],
                 ['lotus/switch-networks', 'Switch networks'],
                 ['lotus/upgrades', 'Upgrades'],

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -77,7 +77,7 @@ module.exports = {
               collapsable: false,
               children: [
                 ['lotus/running-in-the-cloud', 'Running in the Cloud'],
-                ['lotus/installation', 'Install + Setup'],
+                ['lotus/installation', 'Local Installation'],
                 ['lotus/switch-networks', 'Switch networks'],
                 ['lotus/upgrades', 'Upgrades'],
                 ['lotus/send-and-receive-fil', 'Send and receive ⨎'],

--- a/docs/get-started/lotus/installation.md
+++ b/docs/get-started/lotus/installation.md
@@ -8,6 +8,12 @@ breadcrumb: 'Install and setup'
 
 {{ $frontmatter.description }}. This guide covers installing `lotus`, `lotus-miner` and `lotus-worker` to your computer, and then runs through setting up a Lotus node. For information on running the miner, check the [Lotus Miner documentation](../../mine/lotus/README.md).
 
+## Running in the cloud
+
+As an alternative to running locally, you can also run Lotus on a cloud provider. The easiest and cheapest path is to use [the one-click application in the DigitalOcean marketplace](https://marketplace.digitalocean.com/apps/filecoin-lotus?refcode=f37c84619fb2). In addition to being a one-click deployment, you will receive a $100 credit with DigitalOcean for using the provided referral link.
+
+Other options, including Amazon Web Services, are covered in [Running in the cloud](running-in-the-cloud.md).
+
 ## Minimal requirements
 
 To run a Lotus node, your computer must have:

--- a/docs/get-started/lotus/running-in-the-cloud.md
+++ b/docs/get-started/lotus/running-in-the-cloud.md
@@ -12,32 +12,31 @@ breadcrumb: 'Running in the cloud'
 
 ### DigitalOcean
 
-Get started on DigitalOcean by clicking on the link below.
+Get started on DigitalOcean by clicking on the image below.
 
-  [![do-marketplace](../images/cloud/DO_Logo_horizontal_blue.svg)](https://marketplace.digitalocean.com/apps/filecoin-lotus?refcode=f37c84619fb2)
+[![do-marketplace](../images/cloud/DO_Logo_horizontal_blue.svg)](https://marketplace.digitalocean.com/apps/filecoin-lotus?refcode=f37c84619fb2)
 
-You should log into your new DigitalOcean Droplet as `root`
+Log into your new DigitalOcean Droplet as `root` using the password you provided when creating a "Droplet" (virtual machine) with Lotus pre-installed:
 
-  ```
-  ssh root@<your_droplet_public_ipv4>
-  ```
+```
+ssh root@<your_droplet_public_ipv4>
+```
 
 ### Amazon Web Services
 
 We publish AMIs on a regular basis for each of the [filecoin networks](https://networks.filecoin.io/). To use one of these images, just search for one of our AMIs.
 
-  [![aws-search](../images/cloud/Amazon_Web_Services_Logo.svg)](https://us-west-2.console.aws.amazon.com/ec2/v2/home?region=us-west-2#Images:visibility=public-images;search=lotus-mainnet;ownerAlias=657871693752;sort=name)
+[![aws-search](../images/cloud/Amazon_Web_Services_Logo.svg)](https://us-west-2.console.aws.amazon.com/ec2/v2/home?region=us-west-2#Images:visibility=public-images;search=lotus-mainnet;ownerAlias=657871693752;sort=name)
 
-  ![launch-filecoin-ami](../images/cloud/aws-filecoin-ami.png)
+![launch-filecoin-ami](../images/cloud/aws-filecoin-ami.png)
 
 After you launch your AWS instance, you should log in with the 'ubuntu' account.
 The filecoin instance runs a host-based firewall (UFW) which blocks all incomming ports except
 for port 22 and 5678 (libp2p). This works well if you want to place your instance behind a permissive security group.
 
-
-  ```
-  ssh ubuntu@<your_instance_public_ipv4>
-  ```
+```
+ssh ubuntu@<your_instance_public_ipv4>
+```
 
 ## Using the image
 
@@ -45,42 +44,45 @@ As soon as the instance is started, it will download a large file containing the
 
 If you're interested in seeing what's going on, you can view lotus's logs in the systemd journal.
 
-  (optional)
-  ```
-  journalctl -u lotus-daemon
-  ```
+(optional)
+
+```
+journalctl -u lotus-daemon
+```
 
 While the stateroot file is downloading, systemctl will show the status of this job as `Activating`.
 
-  (optional) Notice the this job is not started yet. Don't worry, it will transition into an active state after the stateroot file is imported.
+(optional) Notice the this job is not started yet. Don't worry, it will transition into an active state after the stateroot file is imported.
 
-  ```
-  [mainnet ~] ⨎ systemctl status lotus-daemon
+```
+[mainnet ~] ⨎ systemctl status lotus-daemon
 
-  ● lotus-daemon.service - Lotus Daemon
-     Loaded: loaded (/lib/systemd/system/lotus-daemon.service; disabled; vendor preset: enabled)
-     Active: activating (start-pre) since Sat 2021-04-03 01:36:03 UTC; 7s ago
+● lotus-daemon.service - Lotus Daemon
+   Loaded: loaded (/lib/systemd/system/lotus-daemon.service; disabled; vendor preset: enabled)
+   Active: activating (start-pre) since Sat 2021-04-03 01:36:03 UTC; 7s ago
 Cntrl PID: 1088 (bash)
-      Tasks: 11 (limit: 9513)
-     Memory: 600.8M
-     CGroup: /system.slice/lotus-daemon.service
-             ├─1088 bash /usr/local/bin/lotus-init.sh
-             └─1101 lotus daemon --import-snapshot https://fil-chain-snapshots-fallback.s3.amazonaws>
+    Tasks: 11 (limit: 9513)
+   Memory: 600.8M
+   CGroup: /system.slice/lotus-daemon.service
+           ├─1088 bash /usr/local/bin/lotus-init.sh
+           └─1101 lotus daemon --import-snapshot https://fil-chain-snapshots-fallback.s3.amazonaws>
 
 
 
-  ```
+```
 
-  After about 20 minutes, the stateroot snapshot will have completed its download and lotus will start normally.
+After about 20 minutes, the stateroot snapshot will have completed its download and lotus will start normally.
 
-  ---
-  **NOTE**
-  The stateroot download only happens once, when your instance is initially started. Any future restarts that may occur will not download the stateroot again, so startup will be much faster.
-  ---
+---
 
-  Now that the stateroot has been downloaded successfully, you can interact with the lotus network.
+**NOTE**
+The stateroot download only happens once, when your instance is initially started. Any future restarts that may occur will not download the stateroot again, so startup will be much faster.
 
-  ```
-  [mainnet ~] ⨎ lotus net peers
-  <see current peers here>
-  ```
+---
+
+Now that the stateroot has been downloaded successfully, you can interact with the lotus network.
+
+```
+[mainnet ~] ⨎ lotus net peers
+<see current peers here>
+```

--- a/docs/get-started/lotus/running-in-the-cloud.md
+++ b/docs/get-started/lotus/running-in-the-cloud.md
@@ -12,21 +12,32 @@ breadcrumb: 'Running in the cloud'
 
 ### DigitalOcean
 
-Get started on DigitalOcean by clicking on the image below.
+The easiest and cheapest path is to use [the one-click application in the DigitalOcean marketplace](https://marketplace.digitalocean.com/apps/filecoin-lotus?refcode=f37c84619fb2). In addition to being a one-click deployment, you will receive a $100 credit with DigitalOcean for using the provided referral link.
 
-[![do-marketplace](../images/cloud/DO_Logo_horizontal_blue.svg)](https://marketplace.digitalocean.com/apps/filecoin-lotus?refcode=f37c84619fb2)
+<a href="https://marketplace.digitalocean.com/apps/filecoin-lotus?refcode=f37c84619fb2" alt="DigitalOcean Logo"><img src="../images/cloud/DO_Logo_horizontal_blue.svg" style="max-width: 40%; cursor: hand !important;"/></a>
 
-Log into your new DigitalOcean Droplet as `root` using the password you provided when creating a "Droplet" (virtual machine) with Lotus pre-installed:
+After deploying, log into your new DigitalOcean Droplet as `root` using the password you provided when creating a "Droplet" (virtual machine) with Lotus pre-installed:
 
 ```
 ssh root@<your_droplet_public_ipv4>
 ```
 
+#### Using the DigitalOcean API to deploy Lotus
+
+You can also spin up Lotus nodes programmatically. For example, to create a 4GB filecoin-lotus Droplet in the SFO2 region, you can use the following curl command:
+
+```
+curl -X POST -H 'Content-Type: application/json' \
+-H 'Authorization: Bearer '$TOKEN'' \
+-d '{"name":"a_name","region":"sfo2","size":"s-2vcpu-4gb",
+"image":"protocollabs-filecoinlotus-20-04"}'  "https://api.digitalocean.com/v2/droplets"
+```
+
 ### Amazon Web Services
 
-We publish AMIs on a regular basis for each of the [filecoin networks](https://networks.filecoin.io/). To use one of these images, just search for one of our AMIs.
+We publish AMIs on a regular basis for each of the [filecoin networks](https://networks.filecoin.io/). To use one of these images, just search for one of our AMIs. You can use this [example link which populates a search for Lotus in the `us-west-2` region](https://us-west-2.console.aws.amazon.com/ec2/v2/home?region=us-west-2#Images:visibility=public-images;search=lotus-mainnet;ownerAlias=657871693752;sort=name).
 
-[![aws-search](../images/cloud/Amazon_Web_Services_Logo.svg)](https://us-west-2.console.aws.amazon.com/ec2/v2/home?region=us-west-2#Images:visibility=public-images;search=lotus-mainnet;ownerAlias=657871693752;sort=name)
+<a href="https://us-west-2.console.aws.amazon.com/ec2/v2/home?region=us-west-2#Images:visibility=public-images;search=lotus-mainnet;ownerAlias=657871693752;sort=name" alt="AWS Logo"><img src="../images/cloud/Amazon_Web_Services_Logo.svg" style="max-width: 40%; cursor: hand !important;"/></a>
 
 ![launch-filecoin-ami](../images/cloud/aws-filecoin-ami.png)
 


### PR DESCRIPTION
Add a detour in the "Lotus installation" page just in case someone might be interested in the easier cloud-based option (then, hand off to the nitty-gritty of local installation). Additionally, exposing the draft-ish "Running in the Cloud" article in nav and sprucing it up for prime-time. 