### PR TITLE
Placeholder for API v1 docs.

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -175,7 +175,14 @@ module.exports = {
           '/reference/': [
             'glossary',
             ['https://github.com/filecoin-project/specs', 'Specification'],
-            ['lotus-api', 'Lotus API']
+            {
+              title: 'Lotus API',
+              path: '/reference/lotus/',
+              children: [
+                ['lotus/v0', 'Version 0'],
+                ['lotus/v1', 'Version 1']
+              ]
+            }
           ],
 
           '/': [

--- a/docs/reference/lotus/README.md
+++ b/docs/reference/lotus/README.md
@@ -1,0 +1,17 @@
+---
+title: Lotus APIs
+description: Lotus has two APIs, version 0 and version 1. Version 1 is the most up-to-date, and should be relied upon in production environments. Version 0 is no longer maintained. Any applications or infrastructure using Lotus API version 0 should upgrade to version 1.
+---
+
+# {{ $frontmatter.title }}
+
+{{ $frontmatter.description }}
+
+## [V1](./v1.md)
+
+This is the flagship API version. You should use this version wherever possible.
+
+## [V0](./v0.md)
+
+This version is slowly being deprecated. Use version 1 wherever possible.
+

--- a/docs/reference/lotus/v0.md
+++ b/docs/reference/lotus/v0.md
@@ -1,5 +1,5 @@
 ---
-title: 'Lotus API methods'
+title: 'Lotus API version 0'
 description: 'This page lists all the available methods in the Lotus API. This list is taken directly from the Lotus GitHub repository.'
 ---
 

--- a/docs/reference/lotus/v1.md
+++ b/docs/reference/lotus/v1.md
@@ -1,0 +1,9 @@
+---
+title: Lotus API version 1 
+description: This is the latest version of the Lotus API. 
+---
+
+# Lotus API v1
+
+Lorem ipsum. This page is under construction.
+


### PR DESCRIPTION
This branch contains placeholder information for the Lotus API v1. Once it's stable and the docs have been created, we'll merge this branch, and `/reference/lotus` will have two sub sections:

- V1
- V0

V0 will have a big **deprecated** banner at the top.