### PR TITLE
Complete dependencies for Arch

### DIFF
--- a/docs/get-started/lotus/installation.md
+++ b/docs/get-started/lotus/installation.md
@@ -41,7 +41,7 @@ Building Lotus requires some system dependencies, usually provided by your distr
 Arch:
 
 ```bash
-sudo pacman -Syu opencl-icd-loader gcc git bzr jq pkg-config opencl-icd-loader opencl-headers hwloc
+sudo pacman -Syu opencl-icd-loader gcc git bzr jq pkg-config opencl-icd-loader opencl-headers opencl-nvidia hwloc 
 ```
 
 Ubuntu/Debian:


### PR DESCRIPTION
Current dependencies list for Arch misses `opencl-nvidia`. Without it, `rust-fil-proofs` won't see any Nvidia GPU. Unfortunately, that took me __HOURS__ to understand and waste almost a FIL.