### PR TITLE
add info about addresses to wallet reference & getting started

### DIFF
--- a/docs/get-started/README.md
+++ b/docs/get-started/README.md
@@ -38,10 +38,16 @@ breadcrumb: ''
 
 ## Wallets
 
+Filecoin wallets allow you to manage Fil, Filecoin's native token. Wallets store the private keys that allow you to authorize Filecoin transactions, including paying for storage deals and sending Fil to other accounts. See the [Wallet Addresses reference](/reference/#wallet-addresses) to learn about the kinds of addresses used by Filecoin accounts.
+
+The table below lists the recommended wallet implementations:
+
 | Name                                             |                                                                                                                                                                                             |
 | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [Lotus](lotus/README.md)                         | Lotus can manage bls, sec1p256k1 wallets and supports [Ledger integration](lotus/ledger.md).                                                                                                |
 | [Glif wallet](https://wallet.glif.io/?network=f) | Glif is a lightweight web interface to send and receive Filecoin with a Ledger device ([instructions](https://reading.supply/@glif/install-the-filecoin-app-on-your-ledger-device-y33vhX)). |
+
+Both lotus and the Glif wallet support [Ledger](https://www.ledger.com/) hardware devices, allowing you to use Filecoin without ever storing your private keys on a network-connected device. This can help protect your valuable private keys from malicious software on your computer and is a great idea for accounts with large balances.
 
 There are a number of [additional wallets](https://docs.filecoin.io/reference/#other-wallets) that support Filecoin tokens including mobile wallets.
 

--- a/docs/get-started/README.md
+++ b/docs/get-started/README.md
@@ -38,7 +38,7 @@ breadcrumb: ''
 
 ## Wallets
 
-Filecoin wallets allow you to manage Fil, Filecoin's native token. Wallets store the private keys that allow you to authorize Filecoin transactions, including paying for storage deals and sending Fil to other accounts. See the [Wallet Addresses reference](/reference/#wallet-addresses) to learn about the kinds of addresses used by Filecoin accounts.
+Filecoin wallets allow you to manage FIL, Filecoin's native token. Wallets store the private keys that allow you to authorize Filecoin transactions, including paying for storage deals and sending FIL to other accounts. See the [Wallet Addresses reference](/reference/#wallet-addresses) to learn about the kinds of addresses used by Filecoin accounts.
 
 The table below lists the recommended wallet implementations:
 

--- a/docs/get-started/README.md
+++ b/docs/get-started/README.md
@@ -47,7 +47,7 @@ The table below lists the recommended wallet implementations:
 | [Lotus](lotus/README.md)                         | Lotus can manage bls, sec1p256k1 wallets and supports [Ledger integration](lotus/ledger.md).                                                                                                |
 | [Glif wallet](https://wallet.glif.io/?network=f) | Glif is a lightweight web interface to send and receive Filecoin with a Ledger device ([instructions](https://reading.supply/@glif/install-the-filecoin-app-on-your-ledger-device-y33vhX)). |
 
-Both lotus and the Glif wallet support [Ledger](https://www.ledger.com/) hardware devices, allowing you to use Filecoin without ever storing your private keys on a network-connected device. This can help protect your valuable private keys from malicious software on your computer and is a great idea for accounts with large balances.
+Both Lotus and the Glif wallet support [Ledger](https://www.ledger.com/) hardware devices, allowing you to use Filecoin without ever storing your private keys on a network-connected device. This can help protect your valuable private keys from malicious software on your computer and so is commonly used for accounts with large balances.
 
 There are a number of [additional wallets](https://docs.filecoin.io/reference/#other-wallets) that support Filecoin tokens including mobile wallets.
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -316,7 +316,7 @@ Here's an example of a secp256k1 public key address: `f1abjxfbp274xpdqcpuaykwkfb
 
 Public key addresses are the most common way to refer to Filecoin accounts, and they are supported by hardware wallets like [Ledger](https://ledger.com).
 
-Because a public key address does not depend on any blockchain state, you can use it right away, without waiting for it to be "confirmed". As such, public key addresses are recommended for most use cases involving transfers of FIL, for example, when sending FIL to another user through an exchange.
+Because a public key address does not depend on any blockchain state, they are considered [robust](/about-filecoin/how-filecoin-works.md#robust-addresses-versus-id-addresses) and are recommended for most use cases involving transfers of FIL, for example, when sending FIL to another user through an exchange.
 
 #### ID Addresses
 
@@ -326,11 +326,7 @@ Every ID address for a Filecoin account has an alternative public key address th
 
 Because they are more compact than public key addresses, ID addresses are often used when refering to miners and other long-lived Filecoin [Actors](/about-filecoin/how-filecoin-works.md#actors). As these actors receive a large volume of messages, the compact address can result in meaningful savings in gas fees.
 
-While you can send FIL to an ID address using a wallet, it's generally best to use public key addresses for transfers. This is because ID addresses take some time to be finalized on the blockchain, so a brand new ID address might be re-assigned to a different account than the one you intended. Only send FIL to an `f0` address if you've verified that the account is at least a day old. You can check the address on [FilFox](https://filfox.info/) to see when it was created.
-
-::: warning
-If an ID address is only a few hours old, there's a small chance it will be assigned to a different account during the consensus process. To be safe when sending FIL to an ID address (beginning in `f0`), you should make sure the account has existed for at least a day. If not, use a public key address instead!
-:::
+While you can send FIL to an ID address using a wallet, you should first check the details for the account on [FilFox](https://filfox.info/) to see when the account was created, as well as the corresponding public key address. If the address was created very recently (within the [finality period](/reference/glossary.md#finality)) there is a small chance that it could be re-assigned as the network reaches consensus, and the public key address should be used instead.
 
 ### Filecoin signing tools
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -304,9 +304,9 @@ The wallets below support FIL tokens. We recommend verifying that these have bee
 
 ### Wallet Addresses
 
-When using a wallet, your own account is identified by its [address](/about-filecoin/how-filecoin-works/#addresses). A Filecoin address always starts with the letter `f` and a digit that indicates what type of address it is. The addresses for end-user wallets are generally [public key addresses](/about-filecoin/how-filecoin-works/#public-key-addresses-f1-and-f3), which start with `f1` or `f3` depending on the type of key. Here's an example of a secp256k1 public key address: `f1abjxfbp274xpdqcpuaykwkfb43omjotacm2p3za`.
+When using a wallet, your own account is identified by its [address](/about-filecoin/how-filecoin-works.md#addresses). A Filecoin address always starts with the letter `f` and a digit that indicates what type of address it is. The addresses for end-user wallets are generally [public key addresses](/about-filecoin/how-filecoin-works.md#public-key-addresses-f1-and-f3), which start with `f1` or `f3` depending on the type of key. Here's an example of a secp256k1 public key address: `f1abjxfbp274xpdqcpuaykwkfb43omjotacm2p3za`.
 
-After a short consensus period, the blockchain assigns a short [ID address](/about-filecoin/how-filecoin-works/#id-addresses-f0) for each account, for example: `f033259`. You can find the ID address for any public key address by searching for the public key address on [FilFox](https://filfox.info/), a Filecoin block explorer. 
+After a short consensus period, the blockchain assigns a short [ID address](/about-filecoin/how-filecoin-works.md#id-addresses-f0) for each account, for example: `f033259`. You can find the ID address for any public key address by searching for the public key address on [FilFox](https://filfox.info/), a Filecoin block explorer. 
 
 Because ID addresses depend on the blockchain reaching consensus, you must wait a short time after they are created before using them. If an ID address is only a few hours old, there's a small chance it will be assigned to a different account during the consensus process. To be safe, only send Fil to ID addresses that are at least a day old, and use public key addresses when sending to brand new accounts.
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -29,6 +29,7 @@ This section contains links and reference materials for Filecoin.
 - [Wallets](#wallets)
   - [List of Filecoin wallets](#wallets)
   - [Wallet tools for developers](#wallet-tools-for-developers)
+  - [Wallet addresses](#wallet-addresses)
   - [Filecoin signing tools](#filecoin-signing-tools)
   - [Retrieval Market resources](#retrieval-market-resources-wip-experiments)
 
@@ -300,6 +301,14 @@ The wallets below support FIL tokens. We recommend verifying that these have bee
 - [FilSnap MetaMask Plugin](https://filsnap.netlify.app/) - MetaMask has a new plugin system called [Snaps](https://github.com/MetaMask/metamask-snaps-beta/wiki) currently still in beta that developers can try out
 - A Filecoin light wallet example is in the [Filecoin.js library](https://github.com/filecoin-shipyard/filecoin.js)
 - [Filecoin Rosetta API Proxy](https://github.com/Zondax/rosetta-filecoin) - [Rosetta](https://www.rosetta-api.org/) is an API standard created by Coinbase for a consistent interface to many chains for wallets and exchanges
+
+### Wallet Addresses
+
+When using a wallet, your own account is identified by its [address](/about-filecoin/how-filecoin-works/#addresses). A Filecoin address always starts with the letter `f` and a digit that indicates what type of address it is. The addresses for end-user wallets are generally [public key addresses](/about-filecoin/how-filecoin-works/#public-key-addresses-f1-and-f3), which start with `f1` or `f3` depending on the type of key. Here's an example of a secp256k1 public key address: `f1abjxfbp274xpdqcpuaykwkfb43omjotacm2p3za`.
+
+After a short consensus period, the blockchain assigns a short [ID address](/about-filecoin/how-filecoin-works/#id-addresses-f0) for each account, for example: `f033259`. You can find the ID address for any public key address by searching for the public key address on [FilFox](https://filfox.info/), a Filecoin block explorer. 
+
+Because ID addresses depend on the blockchain reaching consensus, you must wait a short time after they are created before using them. If an ID address is only a few hours old, there's a small chance it will be assigned to a different account during the consensus process. To be safe, only send Fil to ID addresses that are at least a day old, and use public key addresses when sending to brand new accounts.
 
 ### Filecoin signing tools
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -304,11 +304,33 @@ The wallets below support FIL tokens. We recommend verifying that these have bee
 
 ### Wallet Addresses
 
-When using a wallet, your own account is identified by its [address](/about-filecoin/how-filecoin-works.md#addresses). A Filecoin address always starts with the letter `f` and a digit that indicates what type of address it is. The addresses for end-user wallets are generally [public key addresses](/about-filecoin/how-filecoin-works.md#public-key-addresses-f1-and-f3), which start with `f1` or `f3` depending on the type of key. Here's an example of a secp256k1 public key address: `f1abjxfbp274xpdqcpuaykwkfb43omjotacm2p3za`.
+When using a wallet, an account is identified by its [address](/about-filecoin/how-filecoin-works.md#addresses). A Filecoin address always starts with the letter `f` and a digit that indicates what type of address it is.
 
-After a short consensus period, the blockchain assigns a short [ID address](/about-filecoin/how-filecoin-works.md#id-addresses-f0) for each account, for example: `f033259`. You can find the ID address for any public key address by searching for the public key address on [FilFox](https://filfox.info/), a Filecoin block explorer. 
+Filecoin accounts have two kinds of address, **public key** addresses, and **ID** addresses. Both addresses refer to the same account and can be used to send and receive FIL using a wallet.
 
-Because ID addresses depend on the blockchain reaching consensus, you must wait a short time after they are created before using them. If an ID address is only a few hours old, there's a small chance it will be assigned to a different account during the consensus process. To be safe, only send Fil to ID addresses that are at least a day old, and use public key addresses when sending to brand new accounts.
+#### Public Key Addresses
+
+A [public key address](/about-filecoin/how-filecoin-works.md#public-key-addresses-f1-and-f3) is derived directly from a cryptographic key. Public key addresses start with the characters `f1` or `f3`, depending on the type of encryption key used.
+
+Here's an example of a secp256k1 public key address: `f1abjxfbp274xpdqcpuaykwkfb43omjotacm2p3za`.
+
+Public key addresses are the most common way to refer to Filecoin accounts, and they are supported by hardware wallets like [Ledger](https://ledger.com).
+
+Because a public key address does not depend on any blockchain state, you can use it right away, without waiting for it to be "confirmed". As such, public key addresses are recommended for most use cases involving transfers of FIL, for example, when sending FIL to another user through an exchange.
+
+#### ID Addresses
+
+ID addresses are a compact and more "human friendly" way to refer to an account than public key addresses. ID addresses always start with the characters `f0`, followed by a sequence of digits, for example: `f033259`.
+
+Every ID address for a Filecoin account has an alternative public key address that corresponds to the same account. You can find the ID address for any public key address by searching for the public key address on [FilFox](https://filfox.info/), a Filecoin block explorer.
+
+Because they are more compact than public key addresses, ID addresses are often used when refering to miners and other long-lived Filecoin [Actors](/about-filecoin/how-filecoin-works.md#actors). As these actors receive a large volume of messages, the compact address can result in meaningful savings in gas fees.
+
+While you can send FIL to an ID address using a wallet, it's generally best to use public key addresses for transfers. This is because ID addresses take some time to be finalized on the blockchain, so a brand new ID address might be re-assigned to a different account than the one you intended. Only send FIL to an `f0` address if you've verified that the account is at least a day old. You can check the address on [FilFox](https://filfox.info/) to see when it was created.
+
+::: warning
+If an ID address is only a few hours old, there's a small chance it will be assigned to a different account during the consensus process. To be safe when sending FIL to an ID address (beginning in `f0`), you should make sure the account has existed for at least a day. If not, use a public key address instead!
+:::
 
 ### Filecoin signing tools
 

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -55,6 +55,10 @@ When a [storage miner](#storage-miner) fails to complete [Window Proof-of-Spacet
 
 The term _Filecoin_ is used generically to refer to the Filecoin project, protocol, and network.
 
+## Finality
+
+Finality refers to the immutability of messages and state recorded to the Filecoin blockchain. As new blocks are added to the blockchain, it becomes more and more difficult for older blocks to be altered, until they become effectively impossible to modify. The _finality period_ is the amount of time that must elapse before a block is considered completely immutable. In the current [mainnet](#mainnet), this is configured as 900 [epochs](#epoch).
+
 ## Gas
 
 _Gas_ is a property of a [message](#message), corresponding to the resources involved in including that message in a given [block](#block). For each message included in a block, the block's creator extracts a fee from the message's sender; this fee is proportional to the message's gas.


### PR DESCRIPTION
This adds a section to the reference page on the types of addresses used by wallets, with a quick writeup on how to tell the difference between public key and ID addresses and a warning not to send to brand new ID addresses.

I also added a little context to the wallet section on the Getting Started page, which was a little bare.

@johnnymatthews I think I must need to be added to the filecoin-project org or something, since it wouldn't let me push to the main repo. At any rate, this should close https://github.com/filecoin-project/filecoin-docs/issues/816 (cc @autonome)