### PR TITLE
Adds FIP link to homepage.

### DIFF
--- a/docs/.vuepress/theme/components/Home.vue
+++ b/docs/.vuepress/theme/components/Home.vue
@@ -218,6 +218,11 @@ export default {
                 'https://app.instagantt.com/shared/s/1152992274307505/latest'
             },
             {
+              title: 'Filecoin Improvement Program',
+              path:
+                'https://github.com/filecoin-project/FIPs'
+            },
+            {
               title: 'Research',
               path: 'https://research.filecoin.io/'
             },


### PR DESCRIPTION
PR #836 removed the Roadmap link from the homepage. This PR adds a link to the FIP GItHub repo in the Roadmap link's place.