### PR TITLE
Changes `bash` to `shell` in code blocks. [ciskip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ To spin up a local instance of this new VuePress site, see below:
 
 1. Install the NPM dependencies:
 
-   ```bash
+   ```shell
    npm install
    ```
 
 2. Boot up the application in _dev mode_:
 
-   ```bash
+   ```shell
    npm start
    ```
 

--- a/docs/build/get-started.md
+++ b/docs/build/get-started.md
@@ -43,7 +43,7 @@ To make things a bit easier to manage, let's create a new directory for our proj
 
 1. To kick things off, create a new project directory and move into it:
 
-   ```bash
+   ```shell
    mkdir ~/Code/filecoin-wallet-checker -p
    cd ~/Code/filecoin-wallet-checker
    ```
@@ -66,7 +66,7 @@ To make things a bit easier to manage, let's create a new directory for our proj
 
 1. Add the `request` package to this project:
 
-```bash
+```shell
 npm install request
 
 > ...
@@ -207,7 +207,7 @@ We've got some basic functionality in our script, so we should run everything to
 
 1. In your project directory, call the script using `node`:
 
-```bash
+```shell
 node index.js
 
 > Post successful: response:  {"jsonrpc":"2.0","result":{"Cids":[{"/":"bafy2bzaceamdit67mnlyozufeaptmhmti6dv ...
@@ -293,7 +293,7 @@ Instead of asking for the chain head information, let's see if a given string is
 
 1. Let's rerun the script to see what response we get:
 
-   ```bash
+   ```shell
    node index.js
 
    > Response:  {"jsonrpc":"2.0","result":"f1ydrwynitbbfs5ckb7c3qna5cu25la2agmapkchi","id":0}
@@ -301,7 +301,7 @@ Instead of asking for the chain head information, let's see if a given string is
 
    Great! The fact that we got our address back in the `result` field means that our address is valid. If we had sent over an invalid address, we'd get something like this:
 
-   ```bash
+   ```shell
    Response:  {"jsonrpc":"2.0","id":0,"error":{"code":1,"message":"invalid address payload"}}
    ```
 
@@ -333,7 +333,7 @@ Our script checks that a given string is a valid Filecoin address but doesn't do
 
 1. The Infura API will let us know the balance:
 
-   ```bash
+   ```shell
    node index.js
 
    > ADDRESS:  {"jsonrpc":"2.0","result":"7182015146934547358774","id":0}

--- a/docs/build/lotus/go-json-rpc.md
+++ b/docs/build/lotus/go-json-rpc.md
@@ -12,7 +12,7 @@ To use the Lotus Go client, the [go-jsonrpc](https://github.com/filecoin-project
 
 First, you can import the necessary Go module to resolve the dependency:
 
-```bash
+```shell
 $ go get github.com/filecoin-project/go-jsonrpc
 ```
 

--- a/docs/community/contribute/contribution-tutorial.md
+++ b/docs/community/contribute/contribution-tutorial.md
@@ -63,14 +63,14 @@ Here is the process for creating a fork of an existing piece of Filecoin documen
 2. Select **Fork** to create a copy of the project.
 3. Clone your copy of the project down to your local machine:
 
-   ```bash
+   ```shell
    git clone https://github.com/YOUR_USERNAME/filecoin-docs.git
    ```
 
 4. Make your changes locally.
 5. Once all your changes are complete, make sure to push everything back to GitHub:
 
-   ```bash
+   ```shell
    git add .
    git commit -m "Fixed a broken URL, issue #123."
    git push

--- a/docs/community/contribute/grammar-formatting-and-style.md
+++ b/docs/community/contribute/grammar-formatting-and-style.md
@@ -76,13 +76,13 @@ Lotus is the main implementation of Filecoin. As such, it is frequently referenc
 ````markdown
 1. Start the Lotus daemon:
 
-   ```bash
+   ```shell
    lotus daemon
    ```
 
 2. After your Lotus daemon has been running for a few minutes, use `lotus` to check the number of other peers that it is connected to in the Filecoin network:
 
-   ```bash
+   ```shell
    lotus net peers
    ```
 ````
@@ -213,7 +213,7 @@ Tag code blocks with the syntax of the core they are presenting:
 Write command-line inputs without any other characters. Precede outputs from the command line with a greater-than sign `>`. Include an empty line between the input and output of a command-line example:
 
 ````markdown
-    ```bash
+    ```shell
     lotus-miner info
 
     > ~/lotus> lotus-miner info
@@ -231,7 +231,7 @@ Write command-line inputs without any other characters. Precede outputs from the
 Command-line examples can be truncated with three periods `...` to remove extraneous information:
 
 ````markdown
-    ```bash
+    ```shell
     lotus-miner info
 
     > ~/lotus> lotus-miner info
@@ -292,7 +292,7 @@ Use the dollar sign `$` to enter debug-mode.
 
 When instructing the reader to use a keyboard shortcut, surround individual keys in code tags:
 
-```bash
+```shell
 Press `ctrl` + `c` to copy the highlighted text.
 ```
 

--- a/docs/get-started/lotus/chain.md
+++ b/docs/get-started/lotus/chain.md
@@ -29,7 +29,7 @@ These lightweight state snapshots **do not contain any message receipts**. To ge
 
 1. Download the most recent lightweight snapshot and its checksum:
 
-    ```bash
+    ```shell
     curl -sI https://fil-chain-snapshots-fallback.s3.amazonaws.com/mainnet/minimal_finality_stateroots_latest.car | perl -ne '/x-amz-website-redirect-location:\s(.+)\.car/ && print "$1.sha256sum\n$1.car"' | xargs wget
     ```
 
@@ -37,7 +37,7 @@ These lightweight state snapshots **do not contain any message receipts**. To ge
 
 1. Check the `sha256sum` of the downloaded snapshot:
 
-    ```bash
+    ```shell
     # Please change the file name accordingly to the actual downloaded snapshot and sha256sum, in this example it is `minimal_finality_stateroots_517061_2021-02-20_11-00-00.car and minimal_finality_stateroots_517061_2021-02-20_11-00-00.sha256sum`
     echo "$(cut -c 1-64 minimal_finality_stateroots_517061_2021-02-20_11-00-00.sha256sum) minimal_finality_stateroots_517061_2021-02-20_11-00-00.car" | sha256sum --check
     
@@ -46,14 +46,14 @@ These lightweight state snapshots **do not contain any message receipts**. To ge
 
 1. Start the Lotus daemon using `--import-snapshot`:
 
-    ```bash
+    ```shell
     #Please change the file name accordingly to the actual downloaded snapshot, in this example it is `minimal_finality_stateroots_517061_2021-02-20_11-00-00.car`
     lotus daemon --import-snapshot minimal_finality_stateroots_517061_2021-02-20_11-00-00.car
     ```
 
 We strongly recommend you to download and verify the checksum of the snapshot before importing it. However, you can skip the `sha256sum` check and use the snapshot URL directly if you'd prefer:
 
-```bash
+```shell
 lotus daemon --import-snapshot https://fil-chain-snapshots-fallback.s3.amazonaws.com/mainnet/minimal_finality_stateroots_latest.car
 ```
 
@@ -91,7 +91,7 @@ lotus sync status
 
 Use `sync wait` to constantly output the state of your current chain as an ongoing process:
 
-```bash
+```shell
 lotus sync wait
 
 > Worker: 0; Base: 0; Target: 414300 (diff: 414300)
@@ -102,7 +102,7 @@ lotus sync wait
 
 Use `chain getblock` to check when the last synced block was mined:
 
-```bash
+```shell
 date -d @$(./lotus chain getblock $(./lotus chain head) | jq .Timestamp)
 
 > Mon 24 Aug 2020 06:00:00 PM EDT
@@ -112,19 +112,19 @@ date -d @$(./lotus chain getblock $(./lotus chain head) | jq .Timestamp)
 
 A full chain CAR-snapshot can be created `chain export`:
 
-```bash
+```shell
 lotus chain export <filename>
 ```
 
 To back up a certain number of the most recent state roots, use the `--recent-stateroots` option, along with how many state roots you could like to backup:
 
-```bash
+```shell
 lotus chain export --recent-stateroots=2000 <filename>
 ```
 
 To create a _pruned_ snapshot and only include blocks directly referenced by the exported state roots, add the `skip-old-msgs` option:
 
-```bash
+```shell
 lotus chain export --recent-stateroots=2000 --skip-old-msgs <filename>
 ```
 
@@ -132,7 +132,7 @@ lotus chain export --recent-stateroots=2000 --skip-old-msgs <filename>
 
 You can restore snapshots by starting the daemon with the `--import-snapshot` option:
 
-```bash
+```shell
 # Without verification
 lotus daemon --import-snapshot <filename>
 
@@ -142,7 +142,7 @@ lotus daemon --import-chain <filename>
 
 If you do not want the daemon to start once the snapshot has finished, add the `--halt-after-import` flag to the command:
 
-```bash
+```shell
 lotus daemon --import-snapshot --halt-after-import <filename>
 ```
 
@@ -152,18 +152,18 @@ It is possible to _prune_ the current chain data used by Lotus to reduce the nod
 
 1. Stop the Lotus daemon:
 
-```bash
+```shell
 lotus daemon stop
 ```
 
 1. Remove the contents of the `datastore/chain/` folder in the Lotus path:
 
-```bash
+```shell
 rm -rf ~/.lotus/datastore/chain/*
 ```
 
 1. Start the daemon using a [lightweight snapshot](#lightweight-snapshot):
 
-```bash
+```shell
 lotus daemon --import-snapshot https://fil-chain-snapshots-fallback.s3.amazonaws.com/mainnet/minimal_finality_stateroots_latest.car
 ```

--- a/docs/get-started/lotus/installation.md
+++ b/docs/get-started/lotus/installation.md
@@ -92,31 +92,31 @@ Building Lotus requires some system dependencies, usually provided by your distr
 
 Arch:
 
-```bash
+```shell
 sudo pacman -Syu opencl-icd-loader gcc git bzr jq pkg-config opencl-icd-loader opencl-headers opencl-nvidia hwloc 
 ```
 
 Ubuntu/Debian:
 
-```bash
+```shell
 sudo apt install mesa-opencl-icd ocl-icd-opencl-dev gcc git bzr jq pkg-config curl clang build-essential hwloc libhwloc-dev wget -y && sudo apt upgrade -y
 ```
 
 Fedora:
 
-```bash
+```shell
 sudo dnf -y install gcc make git bzr jq pkgconfig mesa-libOpenCL mesa-libOpenCL-devel opencl-headers ocl-icd ocl-icd-devel clang llvm wget hwloc libhwloc-dev
 ```
 
 OpenSUSE:
 
-```bash
+```shell
 sudo zypper in gcc git jq make libOpenCL1 opencl-headers ocl-icd-devel clang llvm hwloc && sudo ln -s /usr/lib64/libOpenCL.so.1 /usr/lib64/libOpenCL.so
 ```
 
 Amazon Linux 2:
 
-```bash
+```shell
 sudo yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm; sudo yum install -y git gcc bzr jq pkgconfig clang llvm mesa-libGL-devel opencl-headers ocl-icd ocl-icd-devel hwloc-devel
 ```
 
@@ -132,7 +132,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
 To build Lotus, you need a working installation of [Go 1.16.4 or higher](https://golang.org/dl/):
 
-```bash
+```shell
 wget -c https://golang.org/dl/go1.16.4.linux-amd64.tar.gz -O - | sudo tar -xz -C /usr/local
 ```
 

--- a/docs/get-started/lotus/multisig.md
+++ b/docs/get-started/lotus/multisig.md
@@ -6,7 +6,7 @@ A multi-signature (multisig) wallet refers to a wallet that requires multiple ke
 
 Use `lotus msig create` to a multisig wallet:
 
-```bash
+```shell
 lotus msig create signerAddress1 signerAddress2 signerAddress3...
 
 > Created new multisig:  f01002 f24mscgjtgymb3dqtm4ycwydh4nhygktgxm3nbgva
@@ -16,7 +16,7 @@ In the above example, `f01002` is the id address and `f24mscgjtgymb3dqtm4ycwydh4
 
 By default, signatures from all signers are required for approving a transaction. However, you can change the number of required approvals by using the `--required` option:
 
-```bash
+```shell
 lotus msig create --required=2 signerAddress1 signerAddress2 signerAddress3
 ```
 
@@ -28,7 +28,7 @@ Any signer of a multisig wallet can _propose_ a transaction. The _proposer_ auto
 
 Use `lotus msig propose` to propose a transaction:
 
-````bash
+````shell
 lotus msig propose --from=proposerAddress walletAddress destinationAddress value
 
 > send proposal in message:  bafy2bzaceajm2mghc5rludlbcr3bnpqgcz5m6gmldq6ycrc4trkejz36tnrqe
@@ -38,7 +38,7 @@ In the above example `bafy2bzaceajm2mghc5rludlbcr3bnpqgcz5m6gmldq6ycrc4trkejz36t
 
 Other signers can use `lotus msig approve` to approve the messages:
 
-```bash
+```shell
 lotus msig approve walletAddress transactionID proposerAddress destinationAddress value
 ````
 
@@ -48,7 +48,7 @@ The value of `transactionID`, `proposerAddress`, `destinationAddress` and `value
 
 Use `lotus msig inspect` to get information about the multisig wallet:
 
-```bash
+```shell
 lotus msig inspect walletaddress
 
 > Balance: 0 FIL

--- a/docs/get-started/lotus/send-and-receive-fil.md
+++ b/docs/get-started/lotus/send-and-receive-fil.md
@@ -44,19 +44,19 @@ More information about Addresses can be found in the [How Filecoin works](../../
 
 ### Create a BLS wallet
 
-```bash
+```shell
 lotus wallet new bls
 ```
 
 ### Create a secp256k1 wallet
 
-```bash
+```shell
 lotus wallet new
 ```
 
 ### Create a multisig wallet
 
-```bash
+```shell
 lotus msig create address1 address2..
 ```
 
@@ -72,19 +72,19 @@ You can create as many addresses as you need. One of them will be the _default a
 
 You can see a list of all addresses for your current node:
 
-```bash
+```shell
 lotus wallet list
 ```
 
 You can see the default address with:
 
-```bash
+```shell
 lotus wallet default
 ```
 
 If you wish, you can change the default address to a different one:
 
-```bash
+```shell
 lotus wallet set-default <address>
 ```
 
@@ -94,7 +94,7 @@ For non-mainnet networks, `FIL` can be obtained from a faucet. A list of faucets
 
 Once you have received some `FIL`, use `wallet balance` to check your balance:
 
-```bash
+```shell
 lotus wallet balance
 ```
 
@@ -104,7 +104,7 @@ Remember that you will only see the latest balance when your daemon is fully syn
 
 Use the `send` command followed by the receiving address and the amount of `FIL` you want to send
 
-```bash
+```shell
 # lotus send <target address> <FIL amount>
 lotus send f1zp2... 3
 
@@ -115,7 +115,7 @@ Lotus will output a transaction hash after a successful transaction. You can vie
 
 Lotus assumes you want to send `FIL` from the _default address_. To send FIL from a specific address, use `--from` followed by the address you want to send `FIL` from. This address must have been created or imported to your Lotus node.
 
-```bash
+```shell
 # lotus send --from=<sender address> <target address> <FIL amount>
 lotus send --from f1zp2... f15zt... 3.141
 
@@ -124,7 +124,7 @@ lotus send --from f1zp2... f15zt... 3.141
 
 For advanced sending options:
 
-```bash
+```shell
 lotus send --help
 ```
 
@@ -140,13 +140,13 @@ Keep your addresses' private keys safe! Do not share them with anyone! Store the
 
 You can export and re-import a wallet, including a different Lotus node. Use `wallet export` to export an address from a node:
 
-```bash
+```shell
 lotus wallet export <address> > <address>.key
 ```
 
 Use `wallet import` to import an address into a node:
 
-```bash
+```shell
 lotus wallet import wallet.private
 ```
 

--- a/docs/get-started/lotus/troubleshooting.md
+++ b/docs/get-started/lotus/troubleshooting.md
@@ -75,7 +75,7 @@ There is a maximum request size for security reasons in case the RPC server is e
 
 If you get a `signal killed` error, it could indcate that there was an error during the build process.
 
-```bash
+```shell
 /usr/local/go/pkg/tool/linux_amd64/link: signal: killed
 make: *** [Makefile:68: lotus] Error 1
 ```
@@ -86,7 +86,7 @@ Double check that your computer meets the [minimum hardware requirements](./inst
 
 You may encounter an error saying that the `go` command was not found:
 
-```bash
+```shell
 sudo make install
 
 > bash: go: command not found

--- a/docs/mine/lotus/backup-and-restore.md
+++ b/docs/mine/lotus/backup-and-restore.md
@@ -14,13 +14,13 @@ This process backs-up metadata of the Lotus miner, which is needed to restore th
 
 1. Create a directory for this backup:
 
-   ```bash
+   ```shell
    mkdir -p ~/lotus-backups/2020-11-15
    ```
 
 1. Call `backup` to backup your miner and supply the destination for the `backup.cbor` file:
 
-   ```bash
+   ```shell
    lotus-miner backup /root/lotus-backups/2020-11-15/backup.cbor
 
    > Success
@@ -28,7 +28,7 @@ This process backs-up metadata of the Lotus miner, which is needed to restore th
 
    Add the `--offline` backup if your miner is not currently running:
 
-   ```bash
+   ```shell
    lotus-miner backup --offline /root/lotus-backups/2020-11-15/backup.cbor
 
    > Success
@@ -36,7 +36,7 @@ This process backs-up metadata of the Lotus miner, which is needed to restore th
 
 1. Backup your `config.toml` and `storage.json` files:
 
-   ```bash
+   ```shell
    cp ~/.lotusminer/config.toml ~/.lotusminer/storage.json /root/lotus-backups/2020-11-15
    ```
 
@@ -49,7 +49,7 @@ The backup is now complete. Always follow the 3-2-1 rule when storing backups:
 1. Copy your `backup.cbor`, `config.toml`, and `storage.json` files to the miner if it is on another computer.
 1. Call `restore` to restore your miner from a backup file:
 
-   ```bash/
+   ```shell/
    lotus-miner init restore /root/lotus-backups/2020-11-15/backup.cbor
 
    > ...
@@ -60,13 +60,13 @@ The backup is now complete. Always follow the 3-2-1 rule when storing backups:
 
 1. Copy `config.toml` and `storage.json` into `~/.lotusminer`:
 
-   ```bash
+   ```shell
    cp lotus-backups/2020-11-15/config.toml lotus-backups/2020-11-15/storage.json .lotusminer
    ```
 
 1. Start your miner:
 
-   ```bash
+   ```shell
    lotus-miner run
    ```
 

--- a/docs/mine/lotus/benchmarks.md
+++ b/docs/mine/lotus/benchmarks.md
@@ -12,7 +12,7 @@ breadcrumb: 'Benchmarks'
 
 1. You must have the Lotus repository on your computer. If you do not have an existing copy of the repository, [clone it from GitHub](https://github.com/filecoin-project/lotus/):
 
-   ```bash
+   ```shell
    git clone https://github.com/filecoin-project/lotus.git ~/lotus
 
    > Cloning into '/root/lotus'...
@@ -23,7 +23,7 @@ breadcrumb: 'Benchmarks'
 
 1. The `lotus` binary must be built and within the `~/lotus` repository folder. If you just cloned the repository or have misplaced the `lotus` binary, build the project:
 
-   ```bash
+   ```shell
    cd ~/lotus
    make clean all && make install
 
@@ -38,7 +38,7 @@ breadcrumb: 'Benchmarks'
 
 1. Call `make lotus-bench` to build the Lotus benchmark binary:
 
-   ```bash
+   ```shell
    make lotus-bench
 
    > rm -f lotus-bench
@@ -55,7 +55,7 @@ breadcrumb: 'Benchmarks'
 
 Use the self-documenting feature of the tool to explore the different commands.
 
-```bash
+```shell
     ./lotus-bench --help
 
     > NAME:
@@ -84,7 +84,7 @@ Use the self-documenting feature of the tool to explore the different commands.
 
 Benchmark a proof computation using `lotus-bench prove [command options] [arguments...]`. For example:
 
-```bash
+```shell
 ./lotus-bench prove
 ```
 
@@ -100,7 +100,7 @@ Available options:
 
 Benchmark a sealing computation using `lotus-bench sealing [command options] [arguments...]`. For example:
 
-```bash
+```shell
 ./lotus-bench sealing
 
 > 2020-11-23T18:05:22.028Z        INFO    lotus-bench     lotus-bench/main.go:78  Starting lotus-bench
@@ -148,7 +148,7 @@ Available options:
 
 Benchmark chain import and validation using `lotus-bench import command [command options] [arguments...]`. For example:
 
-```bash
+```shell
 ./lotus-bench import analyze import.car
 ```
 

--- a/docs/mine/lotus/miner-addresses.md
+++ b/docs/mine/lotus/miner-addresses.md
@@ -113,7 +113,7 @@ This feature is enabled as of 2020-12-09 within the [`master` branch of `filecoi
 
 1. Create two control addresses. Control addresses can be any _type_ of address: `secp256k1 ` or `bls`:
 
-   ```bash
+   ```shell
    lotus wallet new bls
 
    > f3rht...
@@ -133,7 +133,7 @@ This feature is enabled as of 2020-12-09 within the [`master` branch of `filecoi
 3. Wait for around 5 minutes for the addresses to be assigned IDs.
 4. Get ID of those addresses:
 
-   ```bash
+   ```shell
    lotus wallet list -i
 
     > Address   ID        Balance                   Nonce  Default
@@ -143,7 +143,7 @@ This feature is enabled as of 2020-12-09 within the [`master` branch of `filecoi
 
 5. Add control addresses:
 
-   ```bash
+   ```shell
    lotus-miner actor control set --really-do-it=true f0100933 f0100939
 
     > Add f3rht...
@@ -173,7 +173,7 @@ This feature is enabled as of 2020-12-09 within the [`master` branch of `filecoi
 
 Get the balances associated with a miner wallet by calling `info`:
 
-```bash
+```shell
 lotus-miner info
 
 > Miner: t01000
@@ -202,7 +202,7 @@ In this example, the miner ID is `t01000`, it has a total balance of `10582.3215
 
 Transfer funds from the Miner actor address to the owner address by calling `actor withdraw`:
 
-```bash
+```shell
 lotus-miner actor withdraw <amount>
 ```
 

--- a/docs/mine/lotus/miner-lifecycle.md
+++ b/docs/mine/lotus/miner-lifecycle.md
@@ -34,7 +34,7 @@ Shutting down your miner while there are still pending operations could get your
 
 In the following example, `Deadline Open` is 454, which is earlier than `Current Epoch` of 500. This miner should not be shut down or restarted:
 
-```bash
+```shell
 $ lotus-miner proving info
 
 Miner: t01001
@@ -54,7 +54,7 @@ Deadline FaultCutoff: 384 (58m0s ago)
 
 In this next example, the miner can be safely restarted because no `Deadlines` are earlier than `Current Epoch`. You have about 45 minutes before the miner must be back online to declare faults. This is known as the `Deadline FaultCutoff`. If the miner has no faults, you have about an hour.
 
-```bash
+```shell
 $ lotus-miner proving info
 
 Miner: t01000
@@ -74,7 +74,7 @@ Deadline FaultCutoff: 588 (in 45m30s)
 
 The `proving info` examples above show information for the current proving window and deadlines. If you wish to see any upcoming deadlines you can use:
 
-```bash
+```shell
 $ lotus-miner proving deadlines
 ```
 
@@ -84,7 +84,7 @@ Every row corresponds to a deadline (a period of 30 minutes covering 24 hours). 
 
 Before stopping the miner, check the state of your deals to make sure the miner is not receiving data or retrieving data for a client:
 
-```bash
+```shell
 lotus-miner storage-deals list
 lotus-miner retrieval-deals list
 lotus-miner data-transfers list
@@ -92,14 +92,14 @@ lotus-miner data-transfers list
 
 To prevent new deals from coming in while you wait to finish work for the current deadline, you can disable storage and retrieval deals. This ensures that the miner does not find itself in the middle of a new deal when shutting down:
 
-```bash
+```shell
 lotus-miner storage-deals selection reject --online --offline
 lotus-miner retrieval-deals selection reject --online --offline
 ```
 
 After the miner has finished rebooting, the deals can be reset with:
 
-```bash
+```shell
 lotus-miner storage-deals selection reset
 lotus-miner retrieval-deals selection reset
 ```
@@ -108,7 +108,7 @@ lotus-miner retrieval-deals selection reset
 
 To get an overview of your current sectors and states, run:
 
-```bash
+```shell
 lotus-miner sectors list
 ```
 
@@ -118,7 +118,7 @@ Any ongoing sealing operation will be restarted from the last checkpoint, and us
 
 With all the considerations above you can decide on the best moment to shutdown your miner:
 
-```bash
+```shell
 lotus-miner stop
 # When using systemd
 # systemctl stop lotus-miner

--- a/docs/store/lotus/import-data-from-ipfs.md
+++ b/docs/store/lotus/import-data-from-ipfs.md
@@ -14,14 +14,14 @@ To enable this integration, you need to have an [IPFS daemon running in the back
 
 Then, open up `~/.lotus/config.toml` (or if you manually set `$LOTUS_PATH`, look under that directory) and look for the Client field, and set UseIpfs to true.
 
-```bash
+```shell
 [Client]
 UseIpfs = true
 ```
 
 After restarting the lotus daemon, you should be able to [make deals](store-data.md) with data in your IPFS node:
 
-```bash
+```shell
 $ ipfs add -r SomeData
 QmSomeData
 $ ./lotus client deal QmSomeData t01000 0.0000000001 80000

--- a/docs/store/starling.md
+++ b/docs/store/starling.md
@@ -30,7 +30,7 @@ You need to have a couple of things installed before you can interact with Starl
 
 1.  In a new terminal window, get your Lotus API token and endpoint with:
 
-    ```bash
+    ```shell
     lotus auth api-info --perm admin
 
     > FULLNODE_API_INFO=eyJhbGcabdjwieusyiIsInR5cCI6IkpXVCJ9.eyJBbGxvdyI6WyJyZWFkIiwid3JpdGUiLCJzaWduIiwdj3isu2938X0.tmdXnxUflc8nhghfjiwo2l1o9T1QwT0jLskdEV5cYEc:/ip4/127.0.0.1/tcp/1234/http
@@ -40,13 +40,13 @@ You need to have a couple of things installed before you can interact with Starl
 
 1.  Clone the Starling repository:
 
-    ```bash
+    ```shell
     git clone https://github.com/filecoin-project/starling
     ```
 
 1.  Move into the `starling` directory and install the dependencies:
 
-    ```bash
+    ```shell
     cd starling
     npm install
     sudo npm link
@@ -55,7 +55,7 @@ You need to have a couple of things installed before you can interact with Starl
 
 1.  Configure Starling settings:
 
-    ```bash
+    ```shell
     starling config
     ```
 
@@ -63,19 +63,19 @@ You need to have a couple of things installed before you can interact with Starl
 
     a. Store a single file run:
 
-        ```bash
+        ```shell
         starling store full/path/to/file
         ```
 
     b. Store a folder run:
 
-        ```bash
+        ```shell
         starling store full/path/to/folder
         ```
 
     c. Launch the interactive monitoring interface:
 
-        ```bash
+        ```shell
         starling monitor
         ```
 


### PR DESCRIPTION
We'd previous been using `bash` in a lot of the code blocks for syntax highlighting, but turns out that `bash` isn't a valid syntax block type. This PR changes all the ` ```bash ` instances to ` ```shell `.