### PR TITLE
Clarify chain size

### DIFF
--- a/docs/get-started/lotus/installation.md
+++ b/docs/get-started/lotus/installation.md
@@ -20,7 +20,7 @@ To run a Lotus node your computer must have:
 
 - macOS or Linux installed. Windows is not yet supported.
 - 8-core CPU and 32 GiB RAM. Models with support for _Intel SHA Extensions_ (AMD since Zen microarchitecture or Intel since Ice Lake) will significantly speed things up.
-- Enough space to store the current Lotus chain (preferably on an SSD storage medium). The chain grows at approximately 38 GiB per day. The chain can also be [synced from trusted state snapshots and compacted](chain.md).
+- Enough space to store the current Lotus chain (preferably on an SSD storage medium). The chain grows at approximately 38 GiB per day and was 453 GiB large on 2021-06-27. The chain can be [synced from trusted state snapshots and compacted](chain.md).
 
 :::warning
 These are the minimal requirements to run a Lotus node. [Hardware requirements for Miners](../../mine/hardware-requirements.md) are different.


### PR DESCRIPTION
I thought the chain must be many terabytes large, but it is not actually that big.

Knowing it is less than a terabyte makes lotus much more accessible.

Still syncing locally, haven't tried lotus yet myself.  This is the size of yesterday's car file.