### PR TITLE
Fixed link https://stats.testnet.filecoin.io/ to mainnet

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -142,7 +142,7 @@ Tools to check status and details of the network and chain.
 
 ### Network stats
 
-- [Network Stats Dashboard](https://stats.testnet.filecoin.io/) - Grafana
+- [Network Stats Dashboard](https://stats.filecoin.io/) - Grafana
 
 ### Testnet explorers
 


### PR DESCRIPTION
Proposed fix to https://github.com/filecoin-project/filecoin-docs/issues/915