### PR TITLE
Fix the colon absence

### DIFF
--- a/docs/build/lotus/lotus-lite.md
+++ b/docs/build/lotus/lotus-lite.md
@@ -139,12 +139,14 @@ You've got the Lotus executables ready to go, and you have access to a Lotus ful
 1. On the lite-node, create an environment variable called `FULLNODE_API_INFO` and give it the following value while calling `lotus daemon --lite`. Make sure to replace `API_TOKEN` with the token you got from the full-node and `YOUR_FULL_NODE_IP_ADDRESS` with the IP address of your full-node:
 
     ```shell
-    FULLNODE_API_INFO=API_TOKEN/ip4/YOUR_FULL_NODE_IP_ADDRESS/tcp/1234 lotus daemon --lite
+    FULLNODE_API_INFO=API_TOKEN:/ip4/YOUR_FULL_NODE_IP_ADDRESS/tcp/1234 lotus daemon --lite
 
     > 2021-03-02T23:59:50.609Z        INFO    main    lotus/daemon.go:201     lotus repo: /root/.lotus
     > ...
     ```
-
+    
+    The `API_TOKEN` variable must be followed by a colon sign (`:`).
+    
     If you don't have an `API_TOKEN`, you can run the above command without one and just gain read-only access to the full-node:
 
     ```shell


### PR DESCRIPTION
We've been working on enabling Lotus Lite functionality and stuck for some time while trying to make it work with the Lotus token. It appeared that we need to have the `:` (colon) sign between the api token and the actual address, while this documentation may be misleading. Creating this PR to fix the issue.