### PR TITLE
Changes 'networks.filecoin.io' to 'network.filecoin.io'.

### DIFF
--- a/docs/.vuepress/nav/en.js
+++ b/docs/.vuepress/nav/en.js
@@ -4,6 +4,6 @@ module.exports = [
   { text: 'Store', link: '/store/' },
   { text: 'Mine', link: '/mine/' },
   { text: 'Build', link: '/build/' },
-  { text: 'Networks', link: 'https://networks.filecoin.io' },
+  { text: 'Networks', link: 'https://network.filecoin.io' },
   { text: 'Reference', link: '/reference/' }
 ]

--- a/docs/.vuepress/public/_redirects
+++ b/docs/.vuepress/public/_redirects
@@ -4,7 +4,7 @@
 
 /questions.html https://venus.filecoin.io/questions.html
 /go-filecoin-tutorial/*  https://venus.filecoin.io/Getting-Started.html
-/networks/ https://networks.filecoin.io
+/networks/ https://network.filecoin.io
 
 /introduction/what-is-filecoin/ /about-filecoin/what-is-filecoin/
 /introduction/why-filecoin/ /about-filecoin/why-filecoin/

--- a/docs/.vuepress/theme/components/Home.vue
+++ b/docs/.vuepress/theme/components/Home.vue
@@ -53,7 +53,7 @@ export default {
             },
             {
               title: 'Filecoin networks',
-              path: 'https://networks.filecoin.io'
+              path: 'https://network.filecoin.io'
             },
             {
               title: 'Lotus installation and setup',

--- a/docs/get-started/README.md
+++ b/docs/get-started/README.md
@@ -20,7 +20,7 @@ Working with blockchains is difficult, and the inherent complexity of blockchain
 
 - Read [How Filecoin Works](../about-filecoin/how-filecoin-works.md) and [IPFS and Filecoin](../about-filecoin/ipfs-and-filecoin.md).
 - Complete the [Protoschool tutorial](https://proto.school/verifying-storage-on-filecoin/) to get a closer, practical look.
-- Check out the [existing networks](https://networks.filecoin.io).
+- Check out the [existing networks](https://network.filecoin.io).
 - Explore the mainnet using one of the [available block explorers](explore-the-network.md). Discover the blocks, the messages, the scoreboards for miners. Watch the self-adjusting base fee, the deals, and all the things tracked by the chain.
 
 ## Store content on Filecoin

--- a/docs/get-started/lotus/send-and-receive-fil.md
+++ b/docs/get-started/lotus/send-and-receive-fil.md
@@ -90,7 +90,7 @@ lotus wallet set-default <address>
 
 ## Obtaining FIL
 
-For non-mainnet networks, `FIL` can be obtained from a faucet. A list of faucets is available on the [networks dashboard](https://networks.filecoin.io). For mainnet, the easiest is to buy `FIL` from an exchange. Not all exchanges support `FIL`, so do your research before signing up.
+For non-mainnet networks, `FIL` can be obtained from a faucet. A list of faucets is available on the [networks dashboard](https://network.filecoin.io). For mainnet, the easiest is to buy `FIL` from an exchange. Not all exchanges support `FIL`, so do your research before signing up.
 
 Once you have received some `FIL`, use `wallet balance` to check your balance:
 

--- a/docs/store/lotus/store-data.md
+++ b/docs/store/lotus/store-data.md
@@ -55,7 +55,7 @@ If you built your own CAR file, make sure to import it directly with the `--car`
 
 ### Files bigger than a sector
 
-If your file is larger than a sector for the [Filecoin network in use](https://networks.filecoin.io), you will need to split your file into multiple parts first.
+If your file is larger than a sector for the [Filecoin network in use](https://network.filecoin.io), you will need to split your file into multiple parts first.
 
 Storage miners will specify which size(s) they're offering so you can select the best option for you. Smaller sectors are faster, while larger sectors are more cost-effective.
 


### PR DESCRIPTION
networks.filecoin.io redirects to network.filecoin.io (without the `s`). This PR just updates all those links so @filecorgi doesn't complain anymore.