### PR TITLE
Adds missing warning about unauditied wallets.

### DIFF
--- a/docs/about-filecoin/managing-assets.md
+++ b/docs/about-filecoin/managing-assets.md
@@ -27,13 +27,13 @@ Be incredibly cautious when using unaudited wallets. Wallets that _have_ gone th
 
 ## Exchanges
 
-A cryptocurrency exchange, or simply just _exchange_ is a service that lets you swap cash for cryptocurrency, cryptocurrency for cash, or even one cryptocurrency for another cryptocurrency. They work similarly to currency exchanges that you find at airports, where you can swap your home currency for one of the countries you are traveling to. If you have purchased cryptocurrency before, you have likely used an exchange before.
+A cryptocurrency exchange, or simply just _exchange_, is a service that lets you swap cash for cryptocurrency, cryptocurrency for cash, or even one cryptocurrency for another cryptocurrency. They work similarly to currency exchanges that you find at airports, where you can swap your home currency for one of the countries you are traveling to. If you have purchased cryptocurrency before, you have likely used an exchange before.
 
-There are lots of exchanges that allow users to buy, sell, and trade FIL. Websites like [coinmarketcap.com](https://coinmarketcap.com/currencies/filecoin/markets/) keep track of which exchanges support which cryptocurrencies. You can use these lists to help make a decision on which exchange to use.
+There are lots of exchanges that allow users to buy, sell, and trade FIL. Websites like [coinmarketcap.com](https://coinmarketcap.com/currencies/filecoin/markets/) keep track of which exchanges support which cryptocurrencies. You can use these lists to help decide which exchange to use.
 
 ![Coinmarketcap show a list of exchanges that support FIL.](./images/coinmarketcap-exchanges.png)
 
-Once you have found an exchange you want to use, you will have to create an account with that exchange. Many changes have strict verification and Know-Your-Customer (KYC) processes in place, so it may take a few days to create your account. However, most large exchanges are able to verify your information in a few minutes.
+Once you have found an exchange you want to use, you will have to create an account with that exchange. Many changes have strict verification and Know-Your-Customer (KYC) processes in place, so it may take a few days to create your account. However, most large exchanges can verify your information in a few minutes.
 
 Purchasing cryptocurrency varies from exchange to exchange, but the process is usually something like this:
 

--- a/docs/about-filecoin/managing-assets.md
+++ b/docs/about-filecoin/managing-assets.md
@@ -20,7 +20,6 @@ Be incredibly cautious when using unaudited wallets. Wallets that _have_ gone th
 | Glif web wallet                                | Supports sending & receiving FIL. Can be integrated with a Ledger hardware device.                                                   | Yes     |
 | FilSnap MetaMask plugin                        | MetaMask has a plugin system called [Snaps](https://github.com/MetaMask/metamask-snaps-beta/wiki). This system is currently in beta. | No      |
 | [Filfox wallet](https://wallet.filfox.info/en) | A browser-based wallet.                                                                                                              | Unknown |
-| [FilWallet.ai](https://filecoinwallet.com/)           | A desktop wallet aimed largely at the Asia Pacific market.                                                                           | Unknown |
 | [ImToken](https://token.im/)                   | A multi-currency wallet.                                                                                                             | Unknown |
 | [MathWallet](https://mathwallet.org/en-us/)    | A multi-currency wallet.                                                                                                             | Unknown |
 | Trust wallet                                   | A multi-currency wallet. This is the official wallet of Binance.                                                                     | Unknown |

--- a/docs/about-filecoin/managing-assets.md
+++ b/docs/about-filecoin/managing-assets.md
@@ -11,7 +11,7 @@ description: 'Many interactions with the Filecoin network require FIL to process
 
 Wallets allow you to manage your assets without having to deal with a Filecoin node directly.
 
-:::warning Unaudited wallets
+:::danger Unaudited wallets
 Be incredibly cautious when using unaudited wallets. Wallets that _have_ gone through an audit have had their codebase checked by a recognized security firm for security vulnerabilities and potential leaks.
 :::
 

--- a/docs/about-filecoin/managing-assets.md
+++ b/docs/about-filecoin/managing-assets.md
@@ -11,6 +11,10 @@ description: 'Many interactions with the Filecoin network require FIL to process
 
 Wallets allow you to manage your assets without having to deal with a Filecoin node directly.
 
+:::warning Unaudited wallets
+Be incredibly cautious when using unaudited wallets. Wallets that _have_ gone through an audit have had their codebase checked by a recognized security firm for security vulnerabilities and potential leaks.
+:::
+
 | Name                                           | Description                                                                                                                          | Audited |
 | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | ------- |
 | Glif web wallet                                | Supports sending & receiving FIL. Can be integrated with a Ledger hardware device.                                                   | Yes     |

--- a/docs/about-filecoin/managing-assets.md
+++ b/docs/about-filecoin/managing-assets.md
@@ -20,7 +20,7 @@ Be incredibly cautious when using unaudited wallets. Wallets that _have_ gone th
 | Glif web wallet                                | Supports sending & receiving FIL. Can be integrated with a Ledger hardware device.                                                   | Yes     |
 | FilSnap MetaMask plugin                        | MetaMask has a plugin system called [Snaps](https://github.com/MetaMask/metamask-snaps-beta/wiki). This system is currently in beta. | No      |
 | [Filfox wallet](https://wallet.filfox.info/en) | A browser-based wallet.                                                                                                              | Unknown |
-| [FilWallet.ai](https://filwallet.ai)           | A desktop wallet aimed largely at the Asia Pacific market.                                                                           | Unknown |
+| [FilWallet.ai](https://filecoinwallet.com/)           | A desktop wallet aimed largely at the Asia Pacific market.                                                                           | Unknown |
 | [ImToken](https://token.im/)                   | A multi-currency wallet.                                                                                                             | Unknown |
 | [MathWallet](https://mathwallet.org/en-us/)    | A multi-currency wallet.                                                                                                             | Unknown |
 | Trust wallet                                   | A multi-currency wallet. This is the official wallet of Binance.                                                                     | Unknown |


### PR DESCRIPTION
This warning _did_ exist at some point, but it's got lost somewhere. This PR adds a warning to the wallets section pointing out that unaudited wallets are potentially dangerous and should be used with caution.