### PR TITLE
add notes regarding exporting/importing market data with lotus-shed

### DIFF
--- a/docs/mine/lotus/split-markets-miners.md
+++ b/docs/mine/lotus/split-markets-miners.md
@@ -140,8 +140,6 @@ LOTUS_MINER_PATH=~/markets-repo-location ./lotus-miner run
 
 ## Rollback to `lotus-miner` monolith process
 
-> Warning: after rollback, your miner won't be able to serve any storage deals that were made to it while the system was running in multi-process architecture (i.e. with a split `markets` service)
-
 If you want to revert the changes listed above and go back to running `lotus-miner` as a single process, run the following:
 
 1. Make sure that the `mining/sealing/proving` node is publicly exposed, as we will be enabling the markets subsystem on it.
@@ -155,25 +153,33 @@ If you want to revert the changes listed above and go back to running `lotus-min
   EnableMarkets = true
 ```
 
-1. Move back the DAG store directory to the monolith miner node repository
+3. Move back the DAG store directory to the monolith miner node repository
 
 ```shell
 mv ~/markets-repo-location/dagStore ~/.lotusminer/
 ```
 
-1. Restart the `mining/sealing/proving` node (with the default LOTUS_MINER_PATH, which should point to your `mining/sealing/proving` node repo). Note that `lotus-miner` interacts with a given repository depending on the `LOTUS_MINER_PATH` environment variable!
+4. Backup and restore the metadata related to storage deals from the `markets` instance back to the monolith miner instance. Given that storage deals metadata would have changed on the `markets` instance in case you accepted storage deals while running multi-services architecture, we have to copy it back to the monolith miner instance.
+
+```shell
+./lotus-shed market export-datastore --repo ~/markets-repo-location --backup-dir /tmp/deals-backup
+
+./lotus-shed market import-datastore --repo ~/.lotusminer --backup-path /tmp/deals-backup/markets.datastore.backup
+```
+
+5. Restart the `mining/sealing/proving` node (with the default LOTUS_MINER_PATH, which should point to your `mining/sealing/proving` node repo). Note that `lotus-miner` interacts with a given repository depending on the `LOTUS_MINER_PATH` environment variable!
 
 ```shell
 ./lotus-miner run
 ```
 
-1. Fetch the node identity. This is necessary as you have to update your miner's peer identity on-chain, as it was changed to the identity of the markets node during the initialising of the markets service repository.
+6. Fetch the node identity. This is necessary as you have to update your miner's peer identity on-chain, as it was changed to the identity of the markets node during the initialising of the markets service repository.
 
 ```shell
 ./lotus-miner net id
 ```
 
-1. Update the miner's peer id on-chain with the result from the previous step.
+7. Update the miner's peer id on-chain with the result from the previous step.
 
 ```shell
 ./lotus-miner actor set-peer-id 12D3XXXXX

--- a/docs/mine/lotus/split-markets-miners.md
+++ b/docs/mine/lotus/split-markets-miners.md
@@ -66,14 +66,16 @@ export LOTUS_BACKUP_BASE_PATH=~/lotus-backup-location
 lotus-miner run
 ```
 
-## Creating a backup
+## Splitting the `lotus-miner` monolith
+
+### 1. Creating a backup
 
 ```shell
 export LOTUS_BACKUP_BASE_PATH=~/lotus-backup-location
 lotus-miner backup ~/lotus-backup-location/backupfile
 ```
 
-## Create config.toml for the markets service
+### 2. Create `config.toml` for the markets service
 
 You need to create a `config.toml` for the markets node, and have it ready for the next step. For more information see [configuration usage page](https://docs.filecoin.io/get-started/lotus/configuration-and-advanced-usage/) and the [custom storage layout page](https://docs.filecoin.io/mine/lotus/custom-storage-layout/).
 
@@ -95,7 +97,7 @@ Make sure you adjust the `[Libp2p]` section on the `markets` node accordingly - 
 
 The `[Libp2p]` section on the `mining/sealing/proving` node can be removed because this node will no longer be running a Libp2p node.
 
-## Initialising a markets service repository
+### 3. Initialising a `markets` service repository
 
 1. Create authentication tokens for the `markets` node
 
@@ -126,13 +128,13 @@ export LOTUS_MINER_PATH=~/markets-repo-location
 ./lotus-miner actor set-addrs <NEW_MULTIADDR>
 ```
 
-## Move the DAG store directory to the markets node repository
+### 4. Move the DAG store directory to the markets node repository
 
 ```shell
 mv ~/.lotusminer/dagStore ~/markets-repo-location/
 ```
 
-## Start the `mining/sealing/proving` miner process without the markets subsystem
+### 5. Start the `mining/sealing/proving` miner process without the markets subsystem
 
 1. Update your `config.toml` and set `EnableMarkets` option to `false`.
 
@@ -142,7 +144,7 @@ mv ~/.lotusminer/dagStore ~/markets-repo-location/
 ./lotus-miner run
 ```
 
-## Start the `markets` miner process with the markets subsystem
+### 6. Start the `markets` miner process with the markets subsystem
 
 ```shell
 LOTUS_MINER_PATH=~/markets-repo-location ./lotus-miner run

--- a/docs/mine/lotus/split-markets-miners.md
+++ b/docs/mine/lotus/split-markets-miners.md
@@ -85,7 +85,7 @@ In the example commands below, we have placed the `config.toml` in the `~/.lotus
   RemoteListenAddress = "127.0.0.1:8787"
 
 [Libp2p]
-  ListenAddresses = ["/ip4/127.0.0.1/tcp/24001", "/ip6/::/tcp/24001"]
+  ListenAddresses = ["/ip4/0.0.0.0/tcp/24001", "/ip6/::/tcp/24001"]
   AnnounceAddresses = ["/ip4/12.34.56.78/tcp/24001"]
 ```
 

--- a/docs/mine/lotus/split-markets-miners.md
+++ b/docs/mine/lotus/split-markets-miners.md
@@ -73,21 +73,23 @@ export LOTUS_BACKUP_BASE_PATH=~/lotus-backup-location
 lotus-miner backup ~/lotus-backup-location/backupfile
 ```
 
-## Copy config.toml for the markets service
+## Create config.toml for the markets service
 
-You need to generate a `config.toml` for the markets node, and have them ready for the next step. For more information see [configuration usage page](https://docs.filecoin.io/get-started/lotus/configuration-and-advanced-usage/) and the [custom storage layout page](https://docs.filecoin.io/mine/lotus/custom-storage-layout/).
+You need to create a `config.toml` for the markets node, and have it ready for the next step. For more information see [configuration usage page](https://docs.filecoin.io/get-started/lotus/configuration-and-advanced-usage/) and the [custom storage layout page](https://docs.filecoin.io/mine/lotus/custom-storage-layout/).
 
-If you intend to run the `mining/sealing/proving` node on the same machine as the `markets` node, make sure that their listeners do not clash:
+In the example commands below, we have placed the `config.toml` in the `~/.lotusmarket` directory. We are using the following `config.toml`:
 
 ```toml
 [API]
   ListenAddress = "/ip4/127.0.0.1/tcp/8787/http"
   RemoteListenAddress = "127.0.0.1:8787"
+
+[Libp2p]
+  ListenAddresses = ["/ip4/127.0.0.1/tcp/24001", "/ip6/::/tcp/24001"]
+  AnnounceAddresses = ["/ip4/12.34.56.78/tcp/24001"]
 ```
 
-By default the `lotus-miner` API server listens to port 2345, so in the example configuration above, we change the configuration for the `markets` node to listen to `127.0.0.1:8787`.
-
-In the example commands below, we have placed the `config.toml` in the `~/.lotusmarket` directory.
+If you intend to run the `mining/sealing/proving` node on the same machine as the `markets` node, make sure that their listeners do not clash. By default the `lotus-miner` API server listens to port 2345, so in the example configuration above, we change the configuration for the `markets` node to listen to `127.0.0.1:8787`.
 
 Make sure you adjust the `[Libp2p]` section on the `markets` node accordingly - it needs to be publicly accessible, so that clients can make storage and retrieval deals with your system.
 

--- a/docs/mine/lotus/split-markets-miners.md
+++ b/docs/mine/lotus/split-markets-miners.md
@@ -106,7 +106,9 @@ export APISECTORINDEX=`./lotus-miner auth api-info --perm=admin`
 
 2. Initialise the `market` node. This performs a one-time setup of the markets node. Part of that setup includes updating the `Peer ID` and the `Multiaddr` in the miner actor by submitting a message on chain. This is necessary so that storage and retrieval clients know that this miner's **deal-making** endpoint is now publicly dialable/reachable on a new address (the new `market` node).
 
-    Note that `lotus-miner` interacts with one repository or another depending on the `LOTUS_MINER_PATH` environment variable!
+Note that `lotus-miner` interacts with one repository or another depending on the `LOTUS_MINER_PATH` environment variable!
+
+This command should be run on the `markets` miner instance host, as it is creating the `markets` miner instance repository, among other actions.
 
 ```shell
 export LOTUS_MINER_PATH=~/markets-repo-location

--- a/docs/mine/lotus/split-markets-miners.md
+++ b/docs/mine/lotus/split-markets-miners.md
@@ -77,7 +77,7 @@ lotus-miner backup ~/lotus-backup-location/backupfile
 
 You need to create a `config.toml` for the markets node, and have it ready for the next step. For more information see [configuration usage page](https://docs.filecoin.io/get-started/lotus/configuration-and-advanced-usage/) and the [custom storage layout page](https://docs.filecoin.io/mine/lotus/custom-storage-layout/).
 
-In the example commands below, we have placed the `config.toml` in the `~/.lotusmarket` directory. We are using the following `config.toml`:
+In the example commands below, we have placed the `config.toml` in the `~/.lotusmarket` directory, which is not the repository directory for the `markets` instance. The repository directory which we use is `~/markets-repo-location`. We are using the following `config.toml`:
 
 ```toml
 [API]

--- a/docs/mine/lotus/split-markets-miners.md
+++ b/docs/mine/lotus/split-markets-miners.md
@@ -138,6 +138,27 @@ mv ~/.lotusminer/dagStore ~/markets-repo-location/
 LOTUS_MINER_PATH=~/markets-repo-location ./lotus-miner run
 ```
 
+## Interacting with the different miner instances with CLI over JSON RPC
+
+> In case you run more than one miner instance on the same machine, make sure that you have `MINER_API_INFO` environment variable `unset`. If you have it set, you will always be interacting with only one miner process, because it has precedence over `LOTUS_MINER_PATH`.
+
+Now that you have both a `markets` miner process and a `mining/sealing/proving` miner process running, you can confirm that you can interact with each respective process with the following:
+
+1. Get the peer identity of the `markets` miner process
+```shell
+LOTUS_MINER_PATH=~/markets-repo-location ./lotus-miner net id
+```
+
+2. Get a list of storage deals from the `markets` miner process
+```shell
+LOTUS_MINER_PATH=~/markets-repo-location ./lotus-miner storage-deals list
+```
+
+3. Get a list of sectors from the `mining/sealing/proving` miner process
+```shell
+LOTUS_MINER_PATH=~/.lotusminer ./lotus-miner sectors list
+```
+
 ## Rollback to `lotus-miner` monolith process
 
 If you want to revert the changes listed above and go back to running `lotus-miner` as a single process, run the following:

--- a/docs/mine/lotus/split-markets-miners.md
+++ b/docs/mine/lotus/split-markets-miners.md
@@ -104,7 +104,7 @@ export APISEALER=`./lotus-miner auth api-info --perm=admin`
 export APISECTORINDEX=`./lotus-miner auth api-info --perm=admin`
 ```
 
-2. Initialise the `market` node. This performs a one-time setup of the markets node. Part of that setup includes updating the `Peer ID` and the `Multiaddr` in the miner actor by submitting a message on chain. This is necessary so that storage and retrieval clients know that this miner's **deal-making** endpoint is now publicly dialable/reachable on a new address (the new `market` node).
+2. Initialise the `market` node. This performs a one-time setup of the markets node. Part of that setup includes updating the `peer id` in the miner actor by submitting a message on chain. This is necessary so that storage and retrieval clients know that this miner's **deal-making** endpoint is now publicly dialable/reachable on a new address (the new `market` node).
 
 Note that `lotus-miner` interacts with one repository or another depending on the `LOTUS_MINER_PATH` environment variable!
 
@@ -118,6 +118,12 @@ export LOTUS_MINER_PATH=~/markets-repo-location
                            --api-sector-index=$APISECTORINDEX \
                            --config=~/.lotusmarket/config.toml \
                            ~/lotus-backup-location/backupfile
+```
+
+3. Optionally update your miner's `multiaddr` on-chain - in case your `markets` instance is publicly exposed at a different location compared to your exiting monolith miner, you also need to update your `multiaddr` on-chain and advertise the correct one to clients:
+
+```shell
+./lotus-miner actor set-addrs <NEW_MULTIADDR>
 ```
 
 ## Move the DAG store directory to the markets node repository


### PR DESCRIPTION
This PR is adding steps on how to `export/import` a backup with all markets-related metadata, so that users who upgraded to a multi-service architecture and accepted storage deals, can continue to retrieve those deals correctly in case they rollback to a monolith architecture.