### PR TITLE
add snapshot instruction for Testnet

### DIFF
--- a/docs/get-started/lotus/chain.md
+++ b/docs/get-started/lotus/chain.md
@@ -39,7 +39,7 @@ These lightweight state snapshots **do not contain any message receipts**. To ge
 
     **Testnet**
 
-    + Calibration: snapthot is maintained by Filecoin community. Download latest snapshot: [lotus_cali_snapshot_2021_07_14_high_73770.car.tar.xz](https://www.mediafire.com/file/q7tc2bmcc9d09vv/lotus_cali_snapshot_2021_07_14_high_73770.car.tar.xz/file). 
+    + Calibration: snapshot is maintained by Filecoin community. Download latest snapshot: [lotus_cali_snapshot_2021_07_14_high_73770.car.tar.xz](https://www.mediafire.com/file/q7tc2bmcc9d09vv/lotus_cali_snapshot_2021_07_14_high_73770.car.tar.xz/file). 
 
     + Nerpa: also maintained by Filecoin Community.
 

--- a/docs/get-started/lotus/chain.md
+++ b/docs/get-started/lotus/chain.md
@@ -48,9 +48,7 @@ These lightweight state snapshots **do not contain any message receipts**. To ge
       + Option-2: this snapshot is taken with the latest 900 blocks daily which is around 1.2GB now. You can directly import snapshop using:
 
         ```shell
-        lotus daemon --halt-after-import --import-snapshot https://dev.node.glif.io/nerpa00/ipfs/8080/ipfs/$(curl -s https://gist.githubusercontent.com/openworklabbot/d32543d42ed318f6dfde516c3d8668a0/raw/snapshot.log) 
-        or
-        lotus daemon --halt-after-import --import-snapshot https://gateway.ipfs.io/ipfs/$(curl -s https://gist.githubusercontent.com/openworklabbot/d32543d42ed318f6dfde516c3d8668a0/raw/snapshot.log)
+        lotus daemon --halt-after-import --import-snapshot https://dweb.link/ipfs/$(curl -s https://gist.githubusercontent.com/openworklabbot/d32543d42ed318f6dfde516c3d8668a0/raw/snapshot.log) 
         ```
 
 1. Check the `sha256sum` of the downloaded snapshot:

--- a/docs/get-started/lotus/chain.md
+++ b/docs/get-started/lotus/chain.md
@@ -29,11 +29,29 @@ These lightweight state snapshots **do not contain any message receipts**. To ge
 
 1. Download the most recent lightweight snapshot and its checksum:
 
+    **Mainnet**
+
+    + [This URL](https://fil-chain-snapshots-fallback.s3.amazonaws.com/mainnet/minimal_finality_stateroots_latest.car) always contains the latest snapshot available for mainnet.
+
     ```shell
     curl -sI https://fil-chain-snapshots-fallback.s3.amazonaws.com/mainnet/minimal_finality_stateroots_latest.car | perl -ne '/x-amz-website-redirect-location:\s(.+)\.car/ && print "$1.sha256sum\n$1.car"' | xargs wget
     ```
 
-    [This URL](https://fil-chain-snapshots-fallback.s3.amazonaws.com/mainnet/minimal_finality_stateroots_latest.car) always contains the latest snapshot available.
+    **TestNet**
+
+    + Calibration: snapthot is maintained by Filecoin community. Download latest snapshot: [lotus_cali_snapshot_2021_07_14_high_73770.car.tar.xz](https://www.mediafire.com/file/q7tc2bmcc9d09vv/lotus_cali_snapshot_2021_07_14_high_73770.car.tar.xz/file). 
+
+    + Nerpa: also maintained by Filecoin Community.
+
+      + Option-1: download latest snapshot [lotus_nerpa_snapshot_2021_07_14_high_339089.car.tar.xz](https://www.mediafire.com/file/t1j360oyk3tjziv/lotus_nerpa_snapshot_2021_07_14_high_339089.car.tar.xz/file)
+
+      + Option-2: this snapshot is taken with the latest 900 blocks daily which is around 1.2GB now. You can directly import snapshop using:
+
+        ```shell
+        lotus daemon --halt-after-import --import-snapshot https://dev.node.glif.io/nerpa00/ipfs/8080/ipfs/$(curl -s https://gist.githubusercontent.com/openworklabbot/d32543d42ed318f6dfde516c3d8668a0/raw/snapshot.log) 
+        or
+        lotus daemon --halt-after-import --import-snapshot https://gateway.ipfs.io/ipfs/$(curl -s https://gist.githubusercontent.com/openworklabbot/d32543d42ed318f6dfde516c3d8668a0/raw/snapshot.log)
+        ```
 
 1. Check the `sha256sum` of the downloaded snapshot:
 

--- a/docs/get-started/lotus/chain.md
+++ b/docs/get-started/lotus/chain.md
@@ -43,7 +43,7 @@ These lightweight state snapshots **do not contain any message receipts**. To ge
 
     + Nerpa: also maintained by Filecoin Community.
 
-      + Option-1: download latest snapshot [lotus_nerpa_snapshot_2021_07_14_high_339089.car.tar.xz](https://www.mediafire.com/file/t1j360oyk3tjziv/lotus_nerpa_snapshot_2021_07_14_high_339089.car.tar.xz/file)
+      + Option 1: Download the latest static snapshot [lotus_nerpa_snapshot_2021_07_14_high_339089.car.tar.xz](https://www.mediafire.com/file/t1j360oyk3tjziv/lotus_nerpa_snapshot_2021_07_14_high_339089.car.tar.xz/file)
 
       + Option-2: this snapshot is taken with the latest 900 blocks daily which is around 1.2GB now. You can directly import snapshop using:
 

--- a/docs/get-started/lotus/chain.md
+++ b/docs/get-started/lotus/chain.md
@@ -1,6 +1,6 @@
 ---
 title: 'Lotus: chain management'
-description: "The Lotus chain carries the information necessary to compute the current state of the Filecoin network. This guide explains how to manage several aspects of the chain, including how to decrease your node's sync-time by loading the chain from a snapshot."
+description: "The Lotus chain carries the information necessary to compute the current state of the Filecoin network. This guide explains how to manage several aspects of the chain, including how to decrease your node's sync time by loading the chain from a snapshot."
 breadcrumb: 'Chain management'
 ---
 
@@ -40,7 +40,7 @@ These lightweight state snapshots **do not contain any message receipts**. To ge
     **Testnet**
 
     :::warning
-    Testnet snapshots are maintained by Filecoin community voluntarily. Sometimes the snapshots might not be up-to-date. Please double check before you use it.
+    Testnet snapshots are maintained by Filecoin community voluntarily, and may not be up-to-date. Please double check before using them.
     :::
 
     + Calibration: Download latest snapshot: [lotus_cali_snapshot_2021_07_14_high_73770.car.tar.xz](https://www.mediafire.com/file/q7tc2bmcc9d09vv/lotus_cali_snapshot_2021_07_14_high_73770.car.tar.xz/file). 
@@ -58,7 +58,7 @@ These lightweight state snapshots **do not contain any message receipts**. To ge
 1. Check the `sha256sum` of the downloaded snapshot:
 
     ```shell with-output
-    # Please change the file name accordingly to the actual downloaded snapshot and sha256sum, in this example it is `minimal_finality_stateroots_517061_2021-02-20_11-00-00.car and minimal_finality_stateroots_517061_2021-02-20_11-00-00.sha256sum`
+    # Replace the filenames for both `.sha256sum` and `.car` files based on the snapshot you downloaded.
     echo "$(cut -c 1-64 minimal_finality_stateroots_517061_2021-02-20_11-00-00.sha256sum) minimal_finality_stateroots_517061_2021-02-20_11-00-00.car" | sha256sum --check
     ```
     ```
@@ -68,11 +68,11 @@ These lightweight state snapshots **do not contain any message receipts**. To ge
 1. Start the Lotus daemon using `--import-snapshot`:
 
     ```shell
-    #Please change the file name accordingly to the actual downloaded snapshot, in this example it is `minimal_finality_stateroots_517061_2021-02-20_11-00-00.car`
+    # Replace the filename for the `.car` file based on the snapshot you downloaded.
     lotus daemon --import-snapshot minimal_finality_stateroots_517061_2021-02-20_11-00-00.car
     ```
 
-We strongly recommend you to download and verify the checksum of the snapshot before importing it. However, you can skip the `sha256sum` check and use the snapshot URL directly if you'd prefer:
+We strongly recommend that you download and verify the checksum of the snapshot before importing. However, you can skip the `sha256sum` check and use the snapshot URL directly if you prefer:
 
 ```shell
 lotus daemon --import-snapshot https://fil-chain-snapshots-fallback.s3.amazonaws.com/mainnet/minimal_finality_stateroots_latest.car
@@ -80,7 +80,7 @@ lotus daemon --import-snapshot https://fil-chain-snapshots-fallback.s3.amazonaws
 
 ### Full chain snapshot
 
-Full chain snapshots contain every block from genesis until the current tipset. You can trustlessly import these complete snapshots by supplying the `--import-chain` option to recalculate the state during import fully:
+Full chain snapshots contain every block from genesis until the current tipset. You can trustlessly import these complete snapshots by supplying the `--import-chain` option to recalculate the entire state during import:
 
 ```sh
 lotus daemon --import-chain https://fil-chain-snapshots-fallback.s3.amazonaws.com/mainnet/complete_chain_with_finality_stateroots_latest.car
@@ -90,7 +90,7 @@ This operation will take multiple days due to the size and complexity of the Fil
 
 ### Checking sync status
 
-There are two ways to track whether the Lotus daemon is correctly syncing the chain and how far it has yet to go to complete the syncing.
+There are two ways to check your Lotus daemon's chain synching progress.
 
 #### Sync status
 
@@ -112,7 +112,7 @@ worker 0:
 
 #### Sync wait
 
-Use `sync wait` to constantly output the state of your current chain as an ongoing process:
+Use `sync wait` to output the state of your current chain as an ongoing process:
 
 ```shell with-output
 lotus sync wait
@@ -135,13 +135,13 @@ Mon 24 Aug 2020 06:00:00 PM EDT
 
 ## Creating a snapshot
 
-A full chain CAR-snapshot can be created `chain export`:
+A full chain CAR-snapshot can be created with `chain export`:
 
 ```shell
 lotus chain export <filename>
 ```
 
-To back up a certain number of the most recent state roots, use the `--recent-stateroots` option, along with how many state roots you could like to backup:
+To back up a certain number of the most recent state roots, use the `--recent-stateroots` option, along with how many state roots you would like to backup:
 
 ```shell
 lotus chain export --recent-stateroots=2000 <filename>
@@ -165,7 +165,7 @@ lotus daemon --import-snapshot <filename>
 lotus daemon --import-chain <filename>
 ```
 
-If you do not want the daemon to start once the snapshot has finished, add the `--halt-after-import` flag to the command:
+If you do not want the daemon to start once the snapshot has finished, add the `--halt-after-import` flag:
 
 ```shell
 lotus daemon --import-snapshot --halt-after-import <filename>

--- a/docs/get-started/lotus/chain.md
+++ b/docs/get-started/lotus/chain.md
@@ -39,9 +39,13 @@ These lightweight state snapshots **do not contain any message receipts**. To ge
 
     **Testnet**
 
-    + Calibration: snapshot is maintained by Filecoin community. Download latest snapshot: [lotus_cali_snapshot_2021_07_14_high_73770.car.tar.xz](https://www.mediafire.com/file/q7tc2bmcc9d09vv/lotus_cali_snapshot_2021_07_14_high_73770.car.tar.xz/file). 
+    :::warning
+    Testnet snapshots are maintained by Filecoin community voluntarily. Sometimes the snapshots might not be up-to-date. Please double check before you use it.
+    :::
 
-    + Nerpa: also maintained by Filecoin Community.
+    + Calibration: Download latest snapshot: [lotus_cali_snapshot_2021_07_14_high_73770.car.tar.xz](https://www.mediafire.com/file/q7tc2bmcc9d09vv/lotus_cali_snapshot_2021_07_14_high_73770.car.tar.xz/file). 
+
+    + Nerpa:
 
       + Option 1: Download the latest static snapshot [lotus_nerpa_snapshot_2021_07_14_high_339089.car.tar.xz](https://www.mediafire.com/file/t1j360oyk3tjziv/lotus_nerpa_snapshot_2021_07_14_high_339089.car.tar.xz/file)
 

--- a/docs/get-started/lotus/chain.md
+++ b/docs/get-started/lotus/chain.md
@@ -37,7 +37,7 @@ These lightweight state snapshots **do not contain any message receipts**. To ge
     curl -sI https://fil-chain-snapshots-fallback.s3.amazonaws.com/mainnet/minimal_finality_stateroots_latest.car | perl -ne '/x-amz-website-redirect-location:\s(.+)\.car/ && print "$1.sha256sum\n$1.car"' | xargs wget
     ```
 
-    **TestNet**
+    **Testnet**
 
     + Calibration: snapthot is maintained by Filecoin community. Download latest snapshot: [lotus_cali_snapshot_2021_07_14_high_73770.car.tar.xz](https://www.mediafire.com/file/q7tc2bmcc9d09vv/lotus_cali_snapshot_2021_07_14_high_73770.car.tar.xz/file). 
 

--- a/docs/get-started/lotus/chain.md
+++ b/docs/get-started/lotus/chain.md
@@ -45,7 +45,7 @@ These lightweight state snapshots **do not contain any message receipts**. To ge
 
       + Option 1: Download the latest static snapshot [lotus_nerpa_snapshot_2021_07_14_high_339089.car.tar.xz](https://www.mediafire.com/file/t1j360oyk3tjziv/lotus_nerpa_snapshot_2021_07_14_high_339089.car.tar.xz/file)
 
-      + Option-2: this snapshot is taken with the latest 900 blocks daily which is around 1.2GB now. You can directly import snapshop using:
+      + Option 2: Auto-generated snapshot, taken with the latest 900 blocks daily. Size is ~1.2GB as of block height 1,000,000 (August 2021). To import this snapshot directly:
 
         ```shell
         lotus daemon --halt-after-import --import-snapshot https://dweb.link/ipfs/$(curl -s https://gist.githubusercontent.com/openworklabbot/d32543d42ed318f6dfde516c3d8668a0/raw/snapshot.log) 


### PR DESCRIPTION
Update `Get Started -> Lotus -> Chain Management` to add instruction on fast syncing for Testnet, both calibnet and Nerpa.

Since the snapshots for testnet are provided and maintained by voluntary community members, this link might need to be updated periodically. 