### PR TITLE
chore: remove filecoin-ruby client lib

### DIFF
--- a/docs/build/lotus/api-client-libraries.md
+++ b/docs/build/lotus/api-client-libraries.md
@@ -15,7 +15,6 @@ breadcrumb: 'API client libraries'
 API clients take care of the low-level details of making requests and handling responses and let you focus on writing code specific to your project. They can also translate between different programming languages. These Filecoin API clients are currently available:
 
 - [filecoin.js](https://github.com/filecoin-shipyard/filecoin.js) (Javascript, RPC, compatible with Lotus and other wallet backends).
-- [filecoin-ruby](https://github.com/subvisual/filecoin-ruby) (Ruby, RPC, compatible with Lotus)
 - [js-filecoin-api-client](https://github.com/filecoin-shipyard/js-filecoin-api-client) (Javascript, compatible with Venus)
 - [starling-api](https://github.com/smalldata-industries/starling-api) (Javascript, REST, compatible with Lotus)
 - For Go, see the guide on [using Go and JSON-RPC APIs](go-json-rpc.md).


### PR DESCRIPTION
https://github.com/subvisual/filecoin-ruby is currently responding 404.