### PR TITLE
add MARKETS_API_INFO env var

### DIFF
--- a/docs/mine/lotus/miner-setup.md
+++ b/docs/mine/lotus/miner-setup.md
@@ -66,6 +66,7 @@ Similarly, `lotus-miner` (as a client application to the Lotus Miner daemon), ca
 
 ```sh
 export MINER_API_INFO="TOKEN:/ip4/<IP>/tcp/<PORT>/http"
+export MARKETS_API_INFO="TOKEN:/ip4/<IP>/tcp/<PORT>/http"
 ```
 
 ### Adding the necessary swap

--- a/docs/mine/lotus/seal-workers.md
+++ b/docs/mine/lotus/seal-workers.md
@@ -150,6 +150,7 @@ Ensure that workers have access to the following environment variables when they
 # MINER_API_INFO as obtained before
 export TMPDIR=/fast/disk/folder3                    # used when sealing
 export MINER_API_INFO:<TOKEN>:/ip4/<miner_api_address>/tcp/<port>/http`
+export MARKETS_API_INFO:<TOKEN>:/ip4/<miner_api_address>/tcp/<port>/http`
 export BELLMAN_CPU_UTILIZATION=0.875      # optimal value depends on exact hardware
 export FIL_PROOFS_MAXIMIZE_CACHING=1
 export FIL_PROOFS_USE_GPU_COLUMN_BUILDER=1 # when GPU is available


### PR DESCRIPTION
When `lotus-miner` CLI is trying to connect to a remote `lotus-miner` (split between multiple machines, or not), it doesn't have any local repos, but needs to know the location of the `markets-api`, so the user should explicitly specify it in `MARKETS_API_INFO`.

This is an edge case, when the machine on which `lotus-miner` CLI client command is run has no repos, but given the fallback repo locations, it still tries to read `~/.lotusminer` for the API endpoint in case `MARKETS_API_INFO` is not specified.