### PR TITLE
Restart-step after initialization of markets-repo

### DIFF
--- a/docs/mine/lotus/split-markets-miners.md
+++ b/docs/mine/lotus/split-markets-miners.md
@@ -289,6 +289,7 @@ your node.
 ```shell
 lotus-miner actor set-addrs <NEW_MULTIADDR>
 ```
+4. After you finished initializing the `markets` service repository, you should restart the `mining/sealing/proving` node. 
 
 #### Step 4. Consider configuring storage.json on the markets node
 


### PR DESCRIPTION
Adding a restart-step of the `mining/sealing/proving` node, after the markets service repo has been initialized