### PR TITLE
Re-adds deleted line to `actor set-owner` command.

### DIFF
--- a/docs/mine/lotus/miner-addresses.md
+++ b/docs/mine/lotus/miner-addresses.md
@@ -33,7 +33,7 @@ The address chosen to be the miner's _owner address_ is designed to be kept offl
 The owner address can be updated with the following command:
 
 ```sh
-lotus-miner actor set-owner --really-do-it <new address> <old address>
+lotus-miner actor set-owner --really-do-it <new address> <old address> && lotus-miner actor set-owner --really-do-it <new address> <new address>
 ```
 
 The above command will need to be run twice, once by the original owner, and then a second time by the new owner to finalize the transfer.


### PR DESCRIPTION
In PR #990, I deleted what I thought was a duplicate line. However, it turns out that it's not a duplicate command, but it does look very similar. Having both commands on separate lines might cause users, like myself, to assume it's a duplicate and just run the top line. Adding the 2nd part of the command with `&&` should mitigate this potential issue.