### PR TITLE
don't need run twice. because we already write two command in the docs

### DIFF
--- a/docs/mine/lotus/miner-addresses.md
+++ b/docs/mine/lotus/miner-addresses.md
@@ -36,7 +36,6 @@ The owner address can be updated with the following command:
 lotus-miner actor set-owner --really-do-it <new address> <old address> && lotus-miner actor set-owner --really-do-it <new address> <new address>
 ```
 
-The above command will need to be run twice, once by the original owner, and then a second time by the new owner to finalize the transfer.
 
 The old and the new address must be available to the Lotus node. You can [create a new address or import an existing one](../../get-started/lotus/send-and-receive-fil.md).
 

--- a/docs/mine/lotus/split-markets-miners.md
+++ b/docs/mine/lotus/split-markets-miners.md
@@ -482,3 +482,13 @@ As soon as the message is confirmed, clients will know to look for the node iden
 ```shell
 lotus-miner actor set-addrs <NEW_MULTIADDR>
 ```
+9. update the Addresses section of the markets config.toml,Update this section as same  as  mining/sealing/proving node
+> [Addresses]  
+  \#PreCommitControl = ["f00XX1"]  
+  \# CommitControl = ["f00XX2"]  
+    TerminateControl = []  
+  \#  DealPublishControl = ["f00XX3"] 
+    DisableOwnerFallback = false  
+    DisableWorkerFallback = false 
+ 
+Normally, if you initialize the markets node from the config.toml used in the mining/sealing/proving node, the settings in this section will be the same as in the mining/sealing/proving node, but if you are already running a subsystem and have changed the configuration in this area midway through the mining/sealing/ proving node, please make the same changes in the markets node, otherwise the DealPublishControl configuration will not take effect and DealPublish costs will be deducted from the worker wallet.see [this issue](https://github.com/filecoin-project/lotus/issues/7168)


### PR DESCRIPTION
> The above command will need to be run twice, once by the original owner, and then a second time by the new owner to finalize the transfer

I think this statement is based on our old docs version.  now we add two commond to the docs
and this statement  also does not accurately describe the operation.