### PR TITLE
Edit wallet import example command

### DIFF
--- a/docs/get-started/lotus/send-and-receive-fil.md
+++ b/docs/get-started/lotus/send-and-receive-fil.md
@@ -165,7 +165,7 @@ lotus wallet export <address> > <address>.key
 Use `wallet import` to import an address into a node:
 
 ```shell
-lotus wallet import wallet.private
+lotus wallet import <address>.key
 ```
 
 and:


### PR DESCRIPTION
Hello 👋 ! 

I was going through the instructions for making a wallet, and I found wallet export/import sections a little bit confusing. 

The export example creates `<address>.key`, but the import uses a `wallet.private`. This made me wonder if there was a missing step or if there might be something I was missing.

The import worked with `<address>.key`, and I thought it might be a bit more clear if the name of the key in the export and import examples matched.