### PR TITLE
Add callout to Lotus docs.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,9 +16,9 @@ Available storage and pricing is not controlled by any single company. Instead, 
 
 The **Filecoin project documentation** homepage offers all the necessary resources to learn about Filecoin, the software and the tools to contribute to the network, either as a user looking for storage, or as a miner providing it. Here are some links to get you started:
 
-```tip Looking for Lotus?
+:::tip Looking for Lotus?
 Lotus documentation has moved to [lotus.filecoin.io](https://lotus.filecoin.io)
-```
+:::
 
 <!--
 * If you're new to web3 and Filecoin, we recommend checking out [What is Filecoin?](/about-filecoin/what-is-filecoin).

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,10 @@ Available storage and pricing is not controlled by any single company. Instead, 
 
 The **Filecoin project documentation** homepage offers all the necessary resources to learn about Filecoin, the software and the tools to contribute to the network, either as a user looking for storage, or as a miner providing it. Here are some links to get you started:
 
+```tip Looking for Lotus?
+Lotus documentation has moved to [lotus.filecoin.io](https://lotus.filecoin.io)
+```
+
 <!--
 * If you're new to web3 and Filecoin, we recommend checking out [What is Filecoin?](/about-filecoin/what-is-filecoin).
 * Users wanting to learn how Filecoin works, how to run a Filecoin node and how to store content in the network, please head to [Get started](/store/) section.

--- a/docs/build/README.md
+++ b/docs/build/README.md
@@ -7,9 +7,9 @@ description: Documentation to start building applications on Filecoin.
 
 Filecoin is for the builders. If you are excited about the potential of leveraging the Filecoin protocol and decentralized storage network to build game-changing applications, you've come to the right place.
 
-:::tip
-Use one of the community built tools and services to get started. [Take a look now →](../store/README.md)
-:::
+```tip Looking for Lotus?
+Lotus documentation has moved to [lotus.filecoin.io](https://lotus.filecoin.io)
+```
 
 ## Get started
 

--- a/docs/build/README.md
+++ b/docs/build/README.md
@@ -7,9 +7,9 @@ description: Documentation to start building applications on Filecoin.
 
 Filecoin is for the builders. If you are excited about the potential of leveraging the Filecoin protocol and decentralized storage network to build game-changing applications, you've come to the right place.
 
-```tip Looking for Lotus?
+:::tip Looking for Lotus?
 Lotus documentation has moved to [lotus.filecoin.io](https://lotus.filecoin.io)
-```
+:::
 
 ## Get started
 

--- a/docs/get-started/README.md
+++ b/docs/get-started/README.md
@@ -8,8 +8,11 @@ breadcrumb: ''
 
 {{ $frontmatter.description }}
 
-:::tip Quick started guides you should try first 
-Working with blockchains is difficult, and the inherent complexity of blockchains can be overwhelming for new developers. If you're not sure where to begin, we recommend you take a look at these sections before diving into more complex parts of Filecoin:
+working with blockchains is difficult, and the inherent complexity of blockchains can be overwhelming for new developers. If you're not sure where to begin, we recommend you take a look at these sections before diving into more complex parts of Filecoin:
+
+```tip Looking for Lotus?
+Lotus documentation has moved to [lotus.filecoin.io](https://lotus.filecoin.io)
+```
 
 ## Become familiar with the concepts
 
@@ -20,9 +23,7 @@ Working with blockchains is difficult, and the inherent complexity of blockchain
 
 ## Store content on Filecoin
 
-:::tip
 Looking for an easy way to store and access your files on Filecoin? Use one of the community built tools and services to get started. [Take a look now →](../store/README.md)
-:::
 
 - Visit [Slate](https://slate.host/) to store content on Filecoin and make deals from your browser.
 - Install and launch your [Lotus Node](https://lotus.filecoin.io). Setup your first wallet and learn how to [send and receive ⨎](https://lotus.filecoin.io/docs/set-up/manage-fil/) and [make storage deals](https://lotus.filecoin.io/docs/storage-providers/manage-storage-deals/).

--- a/docs/get-started/README.md
+++ b/docs/get-started/README.md
@@ -10,9 +10,9 @@ breadcrumb: ''
 
 working with blockchains is difficult, and the inherent complexity of blockchains can be overwhelming for new developers. If you're not sure where to begin, we recommend you take a look at these sections before diving into more complex parts of Filecoin:
 
-```tip Looking for Lotus?
+:::tip Looking for Lotus?
 Lotus documentation has moved to [lotus.filecoin.io](https://lotus.filecoin.io)
-```
+:::
 
 ## Become familiar with the concepts
 

--- a/docs/mine/README.md
+++ b/docs/mine/README.md
@@ -8,9 +8,9 @@ breadcrumb: Provide
 
 Welcome to the Filecoin documentation for **Storage Providers**.
 
-```tip Looking for Lotus?
+:::tip Looking for Lotus?
 Lotus documentation has moved to [lotus.filecoin.io](https://lotus.filecoin.io)
-```
+:::
 
 {{ $frontmatter.description }} Content in this section will help you to:
 

--- a/docs/mine/README.md
+++ b/docs/mine/README.md
@@ -8,6 +8,10 @@ breadcrumb: Provide
 
 Welcome to the Filecoin documentation for **Storage Providers**.
 
+```tip Looking for Lotus?
+Lotus documentation has moved to [lotus.filecoin.io](https://lotus.filecoin.io)
+```
+
 {{ $frontmatter.description }} Content in this section will help you to:
 
 - Understand [how mining works](how-mining-works.md) and what different types of providers exist.
@@ -17,6 +21,4 @@ Welcome to the Filecoin documentation for **Storage Providers**.
 
 The documentation you will be reading assumes you are familiar with the documentation in the [Get started](../get-started) section, have a general grasp of how Filecoin works and are familiar with Filecoin node software and tooling.
 
-:::warning
 Running a successful storage provisioning operation on Filecoin has high [hardware requirements](hardware-requirements.md) and, apart from a strong familiarity with Filecoin, requires experience in systems deployment and administration.
-:::

--- a/docs/store/README.md
+++ b/docs/store/README.md
@@ -8,9 +8,9 @@ breadcrumb: 'Store'
 
 Storing data on Filecoin lets users harness the power of a distributed network and an open market served by thousands of different storage providers or miners.
 
-```tip Looking for Lotus?
+:::tip Looking for Lotus?
 Lotus documentation has moved to [lotus.filecoin.io](https://lotus.filecoin.io)
-```
+:::
 
 ## Get started
 

--- a/docs/store/README.md
+++ b/docs/store/README.md
@@ -8,6 +8,10 @@ breadcrumb: 'Store'
 
 Storing data on Filecoin lets users harness the power of a distributed network and an open market served by thousands of different storage providers or miners.
 
+```tip Looking for Lotus?
+Lotus documentation has moved to [lotus.filecoin.io](https://lotus.filecoin.io)
+```
+
 ## Get started
 
 Users can use the following software solutions to store data on the Filecoin network:


### PR DESCRIPTION
This PR adds simple callouts to lotus.filecoin.io throughout docs.filecoin.io. The callouts are mostly on the indexes of each section.