### PR TITLE
Reverts back to original VuePress search.

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -25,10 +25,6 @@ module.exports = {
     }
   },
   themeConfig: {
-    algolia: {
-      apiKey: '6c3d7635474cdcd0a0aaf8ca397a4c44',
-      indexName: 'filecoin'
-    },
     betaTestFormUrl:
       'https://docs.google.com/forms/d/1LVaD1B2uyW6Ff0jfU_iQ5mCeyQcHfyQO6BDD99XAgK0/viewform',
     defaultImage: '/images/social-card.png',
@@ -182,6 +178,8 @@ module.exports = {
     }
   },
   plugins: [
+    '@vuepress/search', {
+      searchMaxSuggestions: 10 }, 
     '@vuepress/plugin-back-to-top',
     [
       '@vuepress/active-header-links',

--- a/package-lock.json
+++ b/package-lock.json
@@ -2201,19 +2201,6 @@
       "dev": true,
       "requires": {
         "@vuepress/types": "1.9.7"
-      },
-      "dependencies": {
-        "@vuepress/types": {
-          "version": "1.9.7",
-          "resolved": "https://registry.npmjs.org/@vuepress/types/-/types-1.9.7.tgz",
-          "integrity": "sha512-moLQzkX3ED2o18dimLemUm7UVDKxhcrJmGt5C0Ng3xxrLPaQu7UqbROtEKB3YnMRt4P/CA91J+Ck+b9LmGabog==",
-          "dev": true,
-          "requires": {
-            "@types/markdown-it": "^10.0.0",
-            "@types/webpack-dev-server": "^3",
-            "webpack-chain": "^6.0.0"
-          }
-        }
       }
     },
     "@vuepress/shared-utils": {
@@ -2270,6 +2257,17 @@
             "webpack-chain": "^6.0.0"
           }
         }
+      }
+    },
+    "@vuepress/types": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@vuepress/types/-/types-1.9.7.tgz",
+      "integrity": "sha512-moLQzkX3ED2o18dimLemUm7UVDKxhcrJmGt5C0Ng3xxrLPaQu7UqbROtEKB3YnMRt4P/CA91J+Ck+b9LmGabog==",
+      "dev": true,
+      "requires": {
+        "@types/markdown-it": "^10.0.0",
+        "@types/webpack-dev-server": "^3",
+        "webpack-chain": "^6.0.0"
       }
     },
     "@webassemblyjs/ast": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@vuepress/plugin-back-to-top": "^1.8.2",
     "@vuepress/plugin-google-analytics": "^1.8.2",
     "@vuepress/plugin-last-updated": "^1.8.2",
+    "@vuepress/plugin-search": "^1.9.7",
     "husky": "^7.0.4",
     "lint-staged": "^12.0.2",
     "markdown-it-deflist": "^2.1.0",


### PR DESCRIPTION
Adds the [default VuePress search](https://vuepress.vuejs.org/plugin/official/plugin-search.html#usage) behaviour into the site. This replaces Algolia's Docsearch tool.