### PR TITLE
Remove Protocol Labs example hardware

### DIFF
--- a/docs/storage-provider/storage-provider-architectures.md
+++ b/docs/storage-provider/storage-provider-architectures.md
@@ -11,20 +11,7 @@ breadcrumb: 'Mining architectures'
 This section provides examples for Filecoin storage providing setups to guide providers to plan and make the right choices when acquiring and setting up their storage provider infrastructure. Any storage provider setup must meet the [minimal hardware requirements](hardware-requirements.md).
 
 ::: callout
-We are working to improve this section. If you would like to share your storage provider setup, please use the link at the bottom to edit the page!
+We are working to improve this section. If you would like to share your storage provider setup, please create an issue in the [Filecoin docs repo](https://github.com/filecoin-project/filecoin-docs/issues)!
 :::
 
 [[TOC]]
-
-## Protocol Labs example architecture
-
-The following [`lotus-miner`](https://lotus.filecoin.io) setup was published as part of the [Guide to Filecoin Storage Mining](https://filecoin.io/blog/filecoin-guide-to-storage-mining/) blog post. A PDF is available for download [here](https://filecoin.io/vintage/mining-hardware-config-testnet-v3.pdf):
-
-| Hardware unit        | CPU model                     | GPU                        | RAM        | Disk                        | Processes                                                   | Notes                                                                                       |
-| -------------------- | ----------------------------- | -------------------------- | ---------- | --------------------------- | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| Storage provider + Node | AMD Epyc 7402 (24 cores)      | Nvidia Quadro RTX 6000     | 128-256 GB  | Unspecified                 | 1x lotus <br /><br />1x lotus-miner                         | The provider delegates sealing functions to the workers below.                                 |
-| PC1 workers          | AMD Epyc 7F32 DP/UP (8 cores) | -                          | 128-256 GiB | 6 x 1-2 TiB SSD scratch disk | 6x lotus-worker                                             | Runs 6 [Lotus seal workers](https://lotus.filecoin.io/docs/storage-providers/seal-workers/) in parallel for PreCommit1 phase only.   |
-| PC2, Commit workers  | AMD Epyc 7402 (24 cores)      | 2 x Nvidia Quadro RTX 6000 | 256 GiB     | 2-4 TiB SSD scratch disk(s)  | 1x lotus-worker (PC2) <br /><br /> 1x lotus-worker (Commit) | One [worker](https://lotus.filecoin.io/docs/storage-providers/seal-workers/) dedicated to PreCommit2 and another to the Commit phase |
-| Storage provider + Node | Intel Xeon Platinum Processor 8358 (32 cores) | Nvidia GeForce RTX 3080 series or RTX 3090 | 128-256 GB | Unspecified | 1x lotus<br><br>1x lotus-miner | The provider delegates sealing functions to the workers below. |
-| PC1 workers | Intel Xeon Gold Processor 6346 (16 cores) | - | 128-256 GiB | 6 x 1-2 TiB SSD scratch disk | 6x lotus-worker | Runs 6 Lotus seal workers in parallel for PreCommit1 phase only. |
-| PC2, Commit workers | Intel Xeon Platinum Processor 8358 (32 cores) | 2x Nvidia GeForce RTX 3080 series or RTX 3090 | 256 GiB | 2-4 TiB SSD scratch disk(s) | 1x lotus-worker (PC2)<br><br>1x lotus-worker (Commit) | One worker dedicated to PreCommit2 and another to the Commit phase. |

--- a/docs/storage-provider/storage-provider-architectures.md
+++ b/docs/storage-provider/storage-provider-architectures.md
@@ -13,5 +13,3 @@ This section provides examples for Filecoin storage providing setups to guide pr
 ::: callout
 We are working to improve this section. If you would like to share your storage provider setup, please create an issue in the [Filecoin docs repo](https://github.com/filecoin-project/filecoin-docs/issues)!
 :::
-
-[[TOC]]


### PR DESCRIPTION
Proposal for removing the Protocol Labs example architecture until we get something better in place.

The hardware listed here is severely under-specced (espescially on RAM), and creates confusion for potential new storage providers.