### PR TITLE
Fixes FIL for crypto & Filecoin for network/protocol

### DIFF
--- a/content/en/about-filecoin/chat-and-discussion-forums.md
+++ b/content/en/about-filecoin/chat-and-discussion-forums.md
@@ -1,6 +1,6 @@
 ---
 title: "Chat & discussion forums"
-description: "Connect with the Filecoin community in dicussion forums or on IRC"
+description: "Connect with the Filecoin community in discussion forums or on IRC"
 menu:
     about:
         parent: "about-filecoin-community"

--- a/content/en/about-filecoin/filecoin-compared-to.md
+++ b/content/en/about-filecoin/filecoin-compared-to.md
@@ -72,13 +72,13 @@ Filecoin combines many elements of other file storage and distribution systems. 
     </tr>
 </table>
 
-### Filecoin vs. Bitcoin
+### Filecoin tokens (FIL) vs. Bitcoin tokens (BTC)
 
 <table class="comparison">
     <tr>
         <th></th>
-        <th>Filecoin</th>
-        <th>Bitcoin</th>
+        <th>FIL</th>
+        <th>BTC</th>
     </tr>
     <tr>
         <td>Main use case</td>

--- a/content/en/about-filecoin/how-filecoin-works.md
+++ b/content/en/about-filecoin/how-filecoin-works.md
@@ -7,7 +7,7 @@ menu:
 weight: 20
 ---
 
-This page gives a basic introduction to how the Filecoin network operates. While Filecoin is similar to other cryptocurrencies, there are some differences that developers looking to build on the network should be aware of.
+This page gives a basic introduction to how the Filecoin network operates. While the Filecoin network is similar to other cryptocurrency networks, there are some differences that developers looking to build on the network should be aware of.
 
 ## The Network
 

--- a/content/en/about-filecoin/ipfs-and-filecoin.md
+++ b/content/en/about-filecoin/ipfs-and-filecoin.md
@@ -36,7 +36,7 @@ IPFS is great for getting started using content addressing for all sorts of dist
 Filecoin builds on the content addressing of IPFS to add longer term data persistence using cryptoeconomic incentives. With Filecoin:
 
 - Clients make _storage deals_ with storage providers to store data. The network verifies that the storage providers are correctly storing the data. Small payments are made on a regular basis for the duration of the _storage deal_.
-- Storage providers that do not honor the storage deal are penalised.
+- Storage providers that do not honor the storage deal are penalized.
 - Content retrieval might be offered by storage providers directly, or by specialized retrieval storage providers. The user requesting the data pays for this service.
 - Filecoin excels at storing large amounts of data for long periods of time.
 

--- a/content/en/about-filecoin/managing-assets/index.md
+++ b/content/en/about-filecoin/managing-assets/index.md
@@ -64,9 +64,9 @@ Some exchanges place a limit on how much you can withdraw at once. The exchange 
 
 It may take a few minutes for your FIL to show up in your Lotus address. If you do not see the FIL in your Lotus address 30 minutes after the withdrawal is complete from your exchange, get in touch with your exchange's support team for help.
 
-## Denominations of Filecoin
+## Denominations of FIL
 
-Much like how a US penny represents a fraction of a US dollar, there are many ways to represent value using Filecoin. This is because some actions on the Filecoin network require substantially less value than 1 whole `FIL`. The different denominations of `FIL` are:
+Much like how a US penny represents a fraction of a US dollar, there are many ways to represent value using FIL. This is because some actions on the Filecoin network require substantially less value than 1 whole FIL. The different denominations of FIL are:
 
 | Name     | Decimal             |
 | -------- | ------------------- |

--- a/content/en/build/get-started.md
+++ b/content/en/build/get-started.md
@@ -383,4 +383,4 @@ request(options, (error, response, body) => {
 
 ## Next steps
 
-We've only really dipped our toes into what you can do with this API. The [Infura documentation](https://infura.io/docs/filecoin) is a great resource to determine what you can build. Why not try generating a transaction and sending `FIL` between two accounts using the API? Or get information about a particular storage provider?
+We've only really dipped our toes into what you can do with this API. The [Infura documentation](https://infura.io/docs/filecoin) is a great resource to determine what you can build. Why not try generating a transaction and sending FIL between two accounts using the API? Or get information about a particular storage provider?

--- a/content/en/build/get-started/index.md
+++ b/content/en/build/get-started/index.md
@@ -383,4 +383,4 @@ request(options, (error, response, body) => {
 
 ## Next steps
 
-We've only really dipped our toes into what you can do with this API. The [Infura documentation](https://infura.io/docs/filecoin) is a great resource to determine what you can build. Why not try generating a transaction and sending `FIL` between two accounts using the API? Or get information about a particular storage provider?
+We've only really dipped our toes into what you can do with this API. The [Infura documentation](https://infura.io/docs/filecoin) is a great resource to determine what you can build. Why not try generating a transaction and sending FIL between two accounts using the API? Or get information about a particular storage provider?

--- a/content/en/reference/exchanges.md
+++ b/content/en/reference/exchanges.md
@@ -8,11 +8,11 @@ menu:
 
 ## Filecoin Integration Guide
 
-This page lists the general steps and workflows you need to follow to offer filecoin (FIL) on an exchange. This page is not a complete guide, and you will likely have to have some communication with the Lotus team at some point. However, the information laid out here should give you a solid understanding of the work involved and serve as a jumping-off point for your project.
+This page lists the general steps and workflows you need to follow to offer FIL on an exchange. This page is not a complete guide, and you will likely have to have some communication with the Lotus team at some point. However, the information laid out here should give you a solid understanding of the work involved and serve as a jumping-off point for your project.
 
 ## Running a Filecoin node
 
-If you plan to offer filecoin (FIL) on your exchange, you will need to run a Filecoin node. [Lotus](https://lotus.filecoin.io) is the reference implementation node for the Filecoin network, and as such, is currently the most production-ready implementation available.
+If you plan to offer FIL on your exchange, you will need to run a Filecoin node. [Lotus](https://lotus.filecoin.io) is the reference implementation node for the Filecoin network, and as such, is currently the most production-ready implementation available.
 
 ### Node setup and installation
 

--- a/content/en/storage-provider/how-providing-works.md
+++ b/content/en/storage-provider/how-providing-works.md
@@ -22,9 +22,9 @@ The Filecoin network has multiple types of providers:
 - _Retrieval providers_: (under development) will be responsible for providing quick pipes to retrieve files
 - _Repair providers_: to be implemented
 
-**Storage providers** are the heart of the network. They earn Filecoin by storing data for clients and computing cryptographic proofs to verify storage across time, and they earn rewards for adding new blocks of data. The probability of earning transaction fees and block rewards is proportional to the amount of storage the storage provider contributes to the Filecoin network.
+**Storage providers** are the heart of the network. They earn FIL by storing data for clients and computing cryptographic proofs to verify storage across time, and they earn rewards for adding new blocks of data. The probability of earning transaction fees and block rewards is proportional to the amount of storage the storage provider contributes to the Filecoin network.
 
-**Retrieval providers** will be the veins of the network. They will earn Filecoin by winning bids and provider fees, determined by the market value of the file they're retrieving. A retrieval provider’s bandwidth and bid/initial-response-time for deals (i.e., speed and how close to the client) will determine its ability to close retrieval deals on the network. The maximum bandwidth of a retrieval provider will set the total quantity of deals it can make.
+**Retrieval providers** will be the veins of the network. They will earn FIL by winning bids and provider fees, determined by the market value of the file they're retrieving. A retrieval provider’s bandwidth and bid/initial-response-time for deals (i.e., speed and how close to the client) will determine its ability to close retrieval deals on the network. The maximum bandwidth of a retrieval provider will set the total quantity of deals it can make.
 
 ## Requirements
 

--- a/content/en/storage-provider/how-providing-works/index.md
+++ b/content/en/storage-provider/how-providing-works/index.md
@@ -18,15 +18,17 @@ To see if providing storage and/or retrieval is right for you, consider the requ
 
 The Filecoin network has multiple types of providers:
 
-- _Storage providers_: responsible for storing files and data on the network
-- _Retrieval providers_: (under development) will be responsible for providing quick pipes to retrieve files
-- _Repair providers_: to be implemented
+- _Storage providers_: responsible for storing files and data on the network.
+- _Retrieval providers_: (under development) will be responsible for providing quick pipes to retrieve files.
+- _Repair providers_: to be implemented.
 
-**Storage providers** are the heart of the network. They earn Filecoin by storing data for clients and computing cryptographic proofs to verify storage across time, and they earn rewards for adding new blocks of data. The probability of earning transaction fees and block rewards is proportional to the amount of storage the storage provider contributes to the Filecoin network.
+**Storage providers** are the heart of the network. They earn FIL by storing data for clients and computing cryptographic proofs to verify storage across time, and they earn rewards for adding new blocks of data. The probability of earning transaction fees and block rewards is proportional to the amount of storage the storage provider contributes to the Filecoin network.
 
-**Retrieval providers** will be the veins of the network. They will earn Filecoin by winning bids and provider fees, determined by the market value of the file they're retrieving. A retrieval provider’s bandwidth and bid/initial-response-time for deals (i.e., speed and how close to the client) will determine its ability to close retrieval deals on the network. The maximum bandwidth of a retrieval provider will set the total quantity of deals it can make.
+**Retrieval providers** will be the veins of the network. They will earn FIL by winning bids and provider fees, determined by the market value of the file they're retrieving. A retrieval provider’s bandwidth and bid/initial-response-time for deals (i.e., speed and how close to the client) will determine its ability to close retrieval deals on the network. The maximum bandwidth of a retrieval provider will set the total quantity of deals it can make.
 
-## Hardware requirements
+## Requirements
+
+### Hardware requirements
 
 The hardware requirements for providers are very demanding, but once you acquire them, they're not expected to increase in the foreseeable future. Money spent on hardware should provide you with many years of reliable service, paying for itself several times over.
 
@@ -51,7 +53,7 @@ For an 18-month period, an investment of $147k covered combined capital expenses
 
 See [Filecoin Storage Provider Bootcamp, by ESPA](https://www.youtube.com/watch?v=T-TgPILQD3c) (at 14:47).
 
-## Install Lotus application
+### Lotus application
 
 To store files, you'll need to install Lotus.
 
@@ -59,7 +61,7 @@ Lotus is an application that tells computers how to talk to other computers (tha
 
 See [Lotus > Install > Prerequisites](https://lotus.filecoin.io/lotus/install/prerequisites/).
 
-## Storage provider collateral
+### Storage provider collateral
 
 Most permissionless blockchain networks require an upfront investment in resources to participate in the consensus. The more power an entity has on the network, the greater the share of total resources it needs to own, both in terms of physical resources and/or staked tokens (collateral).
 
@@ -71,13 +73,13 @@ Filecoin includes three different collateral mechanisms:
 
 See [Filecoin Spec](https://spec.filecoin.io/#section-systems.filecoin_mining.miner_collaterals).
 
-## Gas fees
+### Gas fees
 
 You must pay a nominal gas fee for resources used for sealing storage. You can set a gas limit, above which a transaction will not execute, allowing for control.
 
 ![Gas fees are negligible compared to collateral.](collateral-gas.png)
 
-## Storage provider deals
+### Storage provider deals
 
 Deals are the core function of the Filecoin network. Each deal represents a storage agreement between a client and a provider.
 
@@ -89,18 +91,11 @@ Once a client has decided on a provider to store with, they notify the provider 
 
 See [Verifying your deal](https://proto.school/verifying-storage-on-filecoin/06).
 
-For more details on deals from the client's point of view, see:
-
-- [Store data > Create a deal](..get-started/store-and-retrieve/store-data/#create-a-deal)
-- [Retrieve data > Get the deal information](../get-started/store-and-retrieve/retrieve-data/#get-the-deal-information)
-
-## Data transfer
+### Sealing: Proof of Replication (PoRep)
 
 After the deal is published, the client prepares the data for storage and transfers it to the provider. Upon receiving all the data, the provider packs the data into a sector (the fundamental storage unit used by Filecoin) and seals it.
 
 See [Preparing and transferring data](https://proto.school/verifying-storage-on-filecoin/02).
-
-## Sealing: Proof of Replication (PoRep)
 
 Sealing is accomplished by using the first of two kinds of storage proofs:
 
@@ -118,7 +113,7 @@ See:
 - [Proof of Replication (PoRep)](https://proto.school/verifying-storage-on-filecoin/03)
 - [A Guide to Filecoin Storage Mining > Advanced Mining Considerations](https://filecoin.io/blog/posts/a-guide-to-filecoin-storage-mining/)
 
-## Proof of SpaceTime (PoSt)
+### Proof of SpaceTime (PoSt)
 
 Once the data is sealed, the storage provider is ready to begin submitting ongoing proofs to the chain that the data continue to be stored and remain the same.
 
@@ -126,13 +121,13 @@ Throughout the lifetime of the deal, the provider submits ongoing proofs, PoSt, 
 
 See [Proof of Spacetime (PoSt)](https://proto.school/verifying-storage-on-filecoin/04).
 
-## Retrieval provider role
+### Retrieval provider role
 
 Retrieval providers will play a role at the end of a storage provider deal.
 
 To qualify for this role, a potential retrieval provider will need to perform a Proof of Retrievability (PoR), a compact proof that a target file is intact, in the sense that the client can fully recover it.
 
-## zk-SNARKs
+### zk-SNARKs
 
 Both the Proof of Replication and Proof of Spacetime processes use zk-SNARKs for compression.
 
@@ -142,7 +137,7 @@ zk-SNARKs are an important part of consensus mechanisms on the blockchain, becau
 
 See [zk-SNARKs](https://proto.school/verifying-storage-on-filecoin/05).
 
-## Slashing
+### Slashing
 
 _Slashing_ is a set of penalties that are to be paid by storage providers if they fail to provide sector reliability or decide to voluntarily exit the network.
 
@@ -158,7 +153,9 @@ For more information, see:
 - [Verifying your deal](https://proto.school/verifying-storage-on-filecoin/06)
 - [slashing](slashing.md)
 
-## Storage provider power and rewards
+## Rewards
+
+### Storage provider power and rewards
 
 Each Filecoin provider has an associated _power_ value in the network that is proportional to the amount of space contributed and determines the chances to win the right to add a block to an epoch (a specific point on the chain). By adding blocks, providers obtain _block rewards_ and collect fees for the messages included in that block.
 
@@ -168,7 +165,7 @@ Block rewards are meant to bootstrap the Filecoin network. They decrement as rea
 
 See [Storage provider rewards](storage-provider-rewards.md).
 
-## Verified storage deals
+### Verified storage deals
 
 Filecoin Plus aims to enable the demand side of the Filecoin network and maximize the amount of useful storage on Filecoin by adding a layer of social trust to the network and introducing a novel resource called DataCap.
 
@@ -180,7 +177,7 @@ Notaries are selected to serve as fiduciaries for the Filecoin Network and are r
 
 See [Filecoin Plus](https://docs.filecoin.io/store/filecoin-plus/#frontmatter-title).
 
-## Retrieval provider fees
+### Retrieval provider fees
 
 _Retrieval providers_ will not be additionally rewarded with the ability to add blocks to the Filecoin blockchain; their only reward will be the fee they extract from the client.
 


### PR DESCRIPTION
- Found and corrected some instances of Filecoin used where FIL should have been used.
- The [Grammar  & Formatting guide](https://docs.filecoin.io/about-filecoin/grammar-formatting-and-style/#references-to-filecoin) is already very specific and clear about this.
- As I was doing it, I found that there are two files with the same text, except one was older: index.md under storage provider and storage-provider.md. I got the out-of-date one up to date. Should one of these be removed?