### PR TITLE
Adds redirect to help filecoin.io not freak out.

### DIFF
--- a/content/en/get-started/overview/index.md
+++ b/content/en/get-started/overview/index.md
@@ -7,6 +7,7 @@ menu:
         parent: "getstarted-overview"
 aliases:
     - /get-started
+    - /how-to/install-filecoin
 ---
 
 Working with blockchains is difficult, and the inherent complexity of blockchains can be overwhelming for new developers. If you're not sure where to begin, we recommend you take a look at these sections before diving into more complex parts of Filecoin:


### PR DESCRIPTION
There's a link from filecoin.io that's trying to go to `/how-to/install-filecoin`, which doesn't actually exist. This PR points that URL to the Get Started section.