### PR TITLE
Disables copy button.

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -74,7 +74,7 @@ editPage = true
 
 [options]
   lazySizes = true
-  clipBoard = true
+  clipBoard = false
   instantPage = true
   flexSearch = true
   darkMode = true


### PR DESCRIPTION
The copy buttons aren't working, for some reason. There's also a lot of console errors being spat out:

![image](https://user-images.githubusercontent.com/9611008/175340796-5b367c36-3268-49fd-b229-3c5d012cb79e.png)

This PR disables the copy button next to code blocks. This is a temporary measure while we figure out why things aren't working. I have a feeling it's got something to do with the ElasticSearch function that got added recently, but we'll have to do a bit of digging. Either that, or there's some crazy dep that's causing things to break.