### PR TITLE
Removes extra final paren after "slashing" link

### DIFF
--- a/content/en/storage-provider/how-providing-works/index.md
+++ b/content/en/storage-provider/how-providing-works/index.md
@@ -149,7 +149,7 @@ Slashing is a key part of the incentivization that encourages good behavior amon
 For more information, see:
 
 - [Verifying your deal](https://proto.school/verifying-storage-on-filecoin/06)
-- [slashing]({{< relref "slashing" >}}))
+- [slashing]({{< relref "slashing" >}})
 
 ### Retrieval provider role
 


### PR DESCRIPTION
Took a chance editing directly, since we just spent so much time correcting these.... Just removing a stray final parentheses.