### PR TITLE
3 new files for the new dev docs org structure

### DIFF
--- a/build-directly-on-filecoin.md
+++ b/build-directly-on-filecoin.md
@@ -1,0 +1,12 @@
+---
+title: "Build Directly on Filecoin"
+description: "Documentation to start building directly on Filecoin."
+menu:
+    build:
+        parent: "build-get-started"
+        idenfitied: "build-get-started"
+aliases:
+    - /build/get-started
+    - /build
+weight: 3
+---

--- a/upcoming-features.md
+++ b/upcoming-features.md
@@ -1,0 +1,12 @@
+---
+title: "Upcoming Features"
+description: "Documentation to share future Filecoin implementations and features"
+menu:
+    build:
+        parent: "build-get-started"
+        idenfitied: "build-get-started"
+aliases:
+    - /build/get-started
+    - /build
+weight: 1
+---


### PR DESCRIPTION
Child of issue #1263

These three markdown files should be added under content/en/build section as part of structure for upcoming new content