### PR TITLE
Renames Build folder to Developers

### DIFF
--- a/menus.en.toml
+++ b/menus.en.toml
@@ -1,0 +1,179 @@
+[[main]]
+  name = "About Filecoin"
+  url = "/about-filecoin/what-is-filecoin"
+  weight = 10
+  
+[[main]]
+  name = "Networks"
+  url = "/networks/overview"
+  weight = 20
+
+[[main]]
+  name = "Get started"
+  url = "/get-started/overview"
+  weight = 30
+
+[[main]]
+  name = "Store"
+  url = "/store/overview/"
+  weight = 40
+
+[[main]]
+  name = "Storage provider"
+  url = "/storage-provider/overview"
+  weight = 50
+
+[[main]]
+  name = "Developers"
+  url = "/developers/overview"
+  weight = 60
+
+[[main]]
+  name = "Reference"
+  url = "/reference/overview"
+  weight = 70
+
+
+
+[[about]]
+  name = "Basics"
+  weight = 10
+  identifier = "about-filecoin-basics"
+  url = "/about-filecoin/what-is-filecoin"
+
+[[about]]
+  name = "Assets"
+  weight = 20
+  identifier = "about-filecoin-assets"
+  url = "/about-filecoin/managing-assets"
+
+[[about]]
+  name = "Project"
+  weight = 30
+  identifier = "about-filecoin-project"
+  url = "/about-filecoin/project/"
+
+[[about]]
+  name = "Community"
+  weight = 40
+  identifier = "about-filecoin-community"
+  url = "/about-filecoin/chat-and-discussion-forums"
+
+[[about]]
+  name = "Contribute"
+  weight = 50
+  identifier = "about-filecoin-contribute"
+  url = "/about-filecoin/ways-to-contribute"
+
+
+
+[[networks]]
+  name = "Overview"
+  weight = 10
+  identifier = "networks-overview"
+  url = "/networks/"
+
+
+
+[[getstarted]]
+  name = "Overview"
+  weight = 1 
+  identifier = "getstarted-overview"
+  url = "/get-started/overview/"
+
+[[getstarted]]
+  name = "Store and retrieve"
+  weight = 10
+  identifier = "getstarted-store-and-retrieve"
+  url = "/get-started/store-and-retrieve/"
+
+[[getstarted]]
+  name = "Explore"
+  weight = 20
+  identifier = "getstarted-explore"
+  url = "/get-started/explore-the-network/"
+
+
+
+[[store]]
+  name = "Overview"
+  weight = 1
+  identifier = "store-overview"
+  url = "/store/overview"
+
+[[store]]
+  name = "Tools"
+  weight = 10
+  identifier = "store-tools"
+  url = "/store/tools"
+
+[[store]]
+  name = "Filecoin Plus"
+  weight = 20
+  identifier = "store-filecoin-plus"
+  url = "/store/filecoin-plus"
+
+
+
+[[storageprovider]]
+  name = "Basics"
+  weight = 10
+  identifier = "storage-provider-basics"
+  url = "/storage-provider/how-providing-works"
+
+[[storageprovider]]
+  name = "Hardware"
+  weight = 20
+  identifier = "storage-provider-hardware"
+  url = "/storage-provider/hardware-requirements"
+
+[[storageprovider]]
+  name = "Rewards"
+  weight = 30
+  identifier = "storage-provider-rewards"
+  url = "/storage-provider/rewards"
+
+
+
+[[build]]
+  name = "Get building"
+  weight = 10
+  identifier = "build-get-started"
+  url = "/build/overview"
+
+[[build]]
+  name = "Tools"
+  weight = 20
+  identifier = "build-tools"
+  url = "/build/estuary"
+
+
+
+[[reference]]
+  name = "Reference"
+  weight = 10
+  identifier = "reference-reference"
+  url = "/reference/overview"
+
+[[reference]]
+  name = "Exchanges"
+  weight = 20
+  identifier = "reference-exchanges"
+  url = "/reference/exchanges"
+
+
+
+[[social]]
+  name = "GitHub"
+  pre = "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"20\" height=\"20\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\" class=\"feather feather-github\"><path d=\"M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22\"></path></svg>"
+  url = "https://github.com/filecoin-project/filecoin-docs"
+  post = "v0.1.0"
+  weight = 10
+
+[[social]]
+  name = "Twitter"
+  pre = "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"20\" height=\"20\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\" class=\"feather feather-twitter\"><path d=\"M23 3a10.9 10.9 0 0 1-3.14 1.53 4.48 4.48 0 0 0-7.86 3v1A10.66 10.66 0 0 1 3 4s-4 9 5 13a11.64 11.64 0 0 1-7 2c9 5 20 0 20-11.5a4.5 4.5 0 0 0-.08-.83A7.72 7.72 0 0 0 23 3z\"></path></svg>"
+  url = "https://twitter.com/filecoin"
+  weight = 20
+
+


### PR DESCRIPTION
## What? Change name of Build section to Developers

## Why? Align with revamped Filecoin developer docs section

## How? Edits on lines 27-29 to name and url (will edit [[build]] entries under separate PR)

## Testing? N/A
## Screenshots (optional) N/A

## Anything Else? Still sorting out Hugo but this should only change the "Build" appearing in the top navbar to read "Developers". If it does anything else, please ping me so I can try again! 