### PR TITLE
Remove trailing commas from JSON within Getting Started Tutorial code snippets

### DIFF
--- a/content/en/build/get-started/index.md
+++ b/content/en/build/get-started/index.md
@@ -264,7 +264,7 @@ Instead of asking for the chain head information, let's see if a given string is
          "jsonrpc": "2.0",
          "id": 0,
          "method": "Filecoin.WalletValidateAddress",
-         "params": [""],
+         "params": [""]
      }`
    }
    ```
@@ -287,7 +287,7 @@ Instead of asking for the chain head information, let's see if a given string is
          "jsonrpc": "2.0",
          "id": 0,
          "method": "Filecoin.WalletValidateAddress",
-         "params": ["f1ydrwynitbbfs5ckb7c3qna5cu25la2agmapkchi"],
+         "params": ["f1ydrwynitbbfs5ckb7c3qna5cu25la2agmapkchi"]
      }`
    }
    ```


### PR DESCRIPTION
Remove trailing comma from JSON `body` in steps 2 and 3 of 'Validate an Address'