### PR TITLE
Disables copy button again.

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -74,7 +74,7 @@ editPage = true
 
 [options]
   lazySizes = true
-  clipBoard = true
+  clipBoard = false
   instantPage = true
   flexSearch = true
   darkMode = true


### PR DESCRIPTION
The copy button still has some conflicts with the search JS snippets. Removing the copy functionality until we can get around to fixing the search scripts. Closes https://github.com/filecoin-project/filecoin-docs/issues/1391