### PR TITLE
Fix the link to the Glif nodes and add info about CID Checker API

### DIFF
--- a/content/en/reference/overview.md
+++ b/content/en/reference/overview.md
@@ -76,7 +76,7 @@ Tools to check status and details of the network and chain.
 
 - [storageindex.io](https://www.storageindex.io/) - compares storage capacity of different networks
 - [storage.filecoin.io](https://storage.filecoin.io/) - general storage summary of Filecoin
-- [filecoin.tools](https://filecoin.tools) - check your CID's storage deal status
+- [filecoin.tools](https://filecoin.tools) - check your CID's storage deal status. Also provides an API - check [filecoin.tools/docs](https://filecoin.tools/docs) for reference
 - [file.app](https://file.app/) - Filecoin storage provider analytics
 - [Deals list at Filfox.io](https://filfox.info/en/deal)
 
@@ -131,7 +131,7 @@ Developer tools, API clients & storage services that developers can use to build
 
 > NOTE: making deep calls into the chain’s history may take some time to return and it may be more efficient to use a chain database (e.g. used by block explorers) that stores the chain’s history and is optimized for queries.
 
-- [Glif nodes](https://lotus.filecoin.io/developers/glif-nodeshttps://lotus.filecoin.io/developers/glif-nodes/) and [Infura](https://infura.io/docs/filecoin) - Hosted endpoints to Filecoin mainnet and testnet.
+- [Glif nodes](https://lotus.filecoin.io/lotus/developers/glif-nodes/) and [Infura](https://infura.io/docs/filecoin) - Hosted endpoints to Filecoin mainnet and testnet.
   - These endpoints support read-only calls and `MPoolPush()` for sending signed transactions to the network (which can be signed using the [Message signing tools](#message-signing-tools)).
 - [**Lotus JSON-RPC API**](https://lotus.filecoin.io/lotus/get-started/what-is-lotus/) - Lotus offers the full feature set of its capabilities through API.
   - [lotus API Postman sample](https://documenter.getpostman.com/view/4872192/SWLh5mUd?version=latest) - (shows sample wallet calls only)


### PR DESCRIPTION
It seems on main filecoin docs webpage the link to Glif nodes is broken. I found it when I was checking where there is info about CID Checker API out there, so I decided to add these two small fixes, please check ❤️ 