### PR TITLE
Error in Documentation

### DIFF
--- a/content/en/fvm/how-tos/add-to-metamask/index.md
+++ b/content/en/fvm/how-tos/add-to-metamask/index.md
@@ -108,4 +108,4 @@ The process for integrating Filecoin into MetaMask is fairly simple but has some
 
 ## Next steps
 
-You can now add funds to this wallet by using the [Wallaby testnet faucet]({{< relref "#use-the-wallaby-faucet" >}}).
+You can now add funds to this wallet by using the [`Wallaby testnet faucet`](https://wallaby.network/#faucet).

--- a/content/en/fvm/how-tos/add-to-metamask/index.md
+++ b/content/en/fvm/how-tos/add-to-metamask/index.md
@@ -108,4 +108,4 @@ The process for integrating Filecoin into MetaMask is fairly simple but has some
 
 ## Next steps
 
-You can now add funds to this wallet by using the [`Wallaby testnet faucet`](https://wallaby.network/#faucet).
+You can now add funds to this wallet by using the [Wallaby testnet faucet]({{< relref "use-a-faucet" >}}).


### PR DESCRIPTION
When we click on Wallaby testnet faucet the it leads to (https://docs.filecoin.io/fvm/how-tos/add-to-metamask/#use-the-wallaby-faucet) which leads to nothing.
So I updated the link to => (https://wallaby.network/#faucet)