### PR TITLE
Fix/fvm not redirecting

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -11,6 +11,10 @@ languageCode = "en-US"
 paginate = 7
 rssLimit = 10
 
+# Allows you to disable all page types and will render nothing related to 'kind';
+# values = "page", "home", "section", "taxonomy", "taxonomyTerm", "RSS", "sitemap", "robotsTXT", "404"
+disableKinds = ["section"]
+
 # Multilingual
 defaultContentLanguage = "en"
 disableLanguages = ["de", "nl"]

--- a/content/en/build/get-building/overview/index.md
+++ b/content/en/build/get-building/overview/index.md
@@ -6,8 +6,8 @@ menu:
         parent: "build-get-started"
         idenfitied: "build-get-started"
 aliases:
-    - /build/get-started
     - /build
+    - /build/get-started
 weight: 1
 ---
 

--- a/content/en/fvm/basics/introduction/index.md
+++ b/content/en/fvm/basics/introduction/index.md
@@ -8,6 +8,7 @@ menu:
         parent: "fvm-basics"
 aliases:
     - "/fvm"
+    - "/fvm/basics"
 ---
 
 {{< beta-warning >}}

--- a/content/en/fvm/concepts/actors-and-contracts/index.md
+++ b/content/en/fvm/concepts/actors-and-contracts/index.md
@@ -6,6 +6,8 @@ weight: 10
 menu:
     fvm:
         parent: "fvm-concepts"
+aliases:
+    - /fvm/concepts
 ---
 
 {{< beta-warning >}}

--- a/content/en/fvm/how-tos/quickstart/index.md
+++ b/content/en/fvm/how-tos/quickstart/index.md
@@ -6,6 +6,8 @@ weight: 10
 menu:
     fvm:
         parent: "fvm-how-tos"
+aliases:
+    - /fvm/how-tos
 ---
 
 {{< beta-warning >}}

--- a/content/en/fvm/reference/networks/index.md
+++ b/content/en/fvm/reference/networks/index.md
@@ -6,6 +6,8 @@ weight: 10
 menu:
     fvm:
         parent: "fvm-reference"
+aliases:
+    - /fvm/reference
 ---
 
 {{< beta-warning >}}


### PR DESCRIPTION
If you went to `/fvm` you'd be met with an empty page that just said **FVMs** at the top. This PR disables that kind of page, so alises that point to a section or folder now actually work!