### PR TITLE
Clarifies the finality of a tipset.

### DIFF
--- a/content/en/fvm/concepts/tipsets/index.md
+++ b/content/en/fvm/concepts/tipsets/index.md
@@ -12,7 +12,7 @@ menu:
 
 The Filecoin network produces multiple blocks at every epoch. In simple terms, block producers run a local function that uses their _quality-adjusted power_, as represented in the power table, and randomness from the Drand network to determine if they're eligible to produce a block for the current epoch. This consensus protocol is called _expected consensus_.
 
-These blocks are assembled in a **tipset**, and the execution of their messages is deferred to the next tipset. Theoretically, there can be `0` to infinite blocks in a tipset. In practice, however, we see `5` to `10` blocks per tipset.
+These blocks are assembled in a _tipset_, and the execution of their messages is deferred to the next tipset. The state of block `x` is updated and final once block `X+ 1` is reported. Theoretically, there can be `0` to infinite blocks in a tipset. In practice, however, we see `5` to `10` blocks per tipset.
 
 Wherever you see the term _block_ in the Ethereum JSON-RPC, you should mentally read _tipset_. Before FEVM and the Filecoin Ethereum JSON-RPC, there was no single hash referring to a tipset. A tipset ID was the concatenation of block CIDs, which led to a variable length ID, and a pretty poor experience.
 


### PR DESCRIPTION
Suggestion [taken from Slack](https://filecoinproject.slack.com/archives/C029MT4PQB1/p1670441237698649):

```plaintext
Filecoin => FEVM translation question:
I'm trying to work around some of the RPC bugs while they are being worked on. One approach I'm trying in order to retrieve logs is to query every block for logs and determine if they are logs I want.
Because I can't filter for new blocks, what I do is poll eth_blockNumber to get the current block number and if I see a new block number, I call eth_getLogs . But the behavior I'm seeing is I query block 5, I don't see any logs. And then once block 6 or 7 is reported, I query block 5 and the logs I expect are present.
So my question is, filecoin tipsets are not final even when the corresponding FEVM block number is reported by eth_blockNumber? Or at least, the state updates from tipset X are not applied for corresponding block Y until block Y + 1? Is there a predictable formula, for instance, when I see FEVM block N, I can query block N-1 and see all state updates / logs?
This statement in FVM docs seems to claim so, but I want to make sure my understanding is correct
These blocks are assembled in a tipset, and the execution of their messages is deferred to the next tipset.
From https://docs.filecoin.io/fvm/concepts/tipsets/
Filecoin DocsFilecoin Docs
[Tipsets](https://docs.filecoin.io/fvm/concepts/tipsets/)
The Filecoin network uses the idea of tipsets to manage blocks within the blockchain. This page details what a tipset is, how they differ to blocks in other blockchains, and how developers should deal with tipsets. (29 kB)


truckerfling
  [14 hours ago](https://filecoinproject.slack.com/archives/C029MT4PQB1/p1670466729933039?thread_ts=1670441237.698649&cid=C029MT4PQB1)
good point identified. depending on the answer, we could update the sentence to, for example:
These blocks are assembled in a tipset, and the execution of their messages is deferred to the next tipset. The state of block X is updated and final, once block X+1 is reported.
```