### PR TITLE
update the link to community events calendar

### DIFF
--- a/content/en/store/filecoin-plus.md
+++ b/content/en/store/filecoin-plus.md
@@ -136,6 +136,7 @@ There are a few different ways in which a client can find a storage provider to 
 If you are interested in participating in governance and shaping the program, here is how you can get involved:
 
 - Join the [#fil-plus](https://filecoinproject.slack.com/archives/C01DLAPKDGX) channel on Filecoin Slack
-- Participate in Community Governance calls, which happen every other Tuesday. Use the Filecoin Community Events calendar to join or watch for updates in #fil-plus
+- Participate in Community Governance calls, which happen every other Tuesday. Use the [Filecoin Community Events Calendar](https://calendar.google.com/calendar/u/1?cid=Y19rMWdrZm9vbTE3ZzBqOGM2YmFtNnVmNDNqMEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t)
+to join or watch for updates in #fil-plus
 - Create and comment on open issues in the [notary governance repo](https://github.com/filecoin-project/notary-governance/issues)
 


### PR DESCRIPTION
add the link to Filecoin Community Events Calendar, easier for new notaries and clients to find it and attached to their own calendar for the upcoming meetings. 