### PR TITLE
Updates Factor8 wallaby docs links.

### DIFF
--- a/content/en/fvm/basics/faqs/index.md
+++ b/content/en/fvm/basics/faqs/index.md
@@ -77,7 +77,7 @@ Not necessarily. You can use one of the two public Wallaby nodes:
 
 ### How do I install a node on the Wallaby testnet?
 
-Factor8, the team that runs the Wallaby testnet, has a [guide on how to spin up a Lotus node on the Wallaby testnet](https://kb.factor8.io/en/docs/fil/wallabynet).
+Factor8, the team that runs the Wallaby testnet, has a [guide on how to spin up a Lotus node on the Wallaby testnet](https://kb.factor8.dev/docs/filecoin/testnets/wallaby).
 
 ### What is the difference between the FVM and Bacalhau
 

--- a/content/en/fvm/reference/networks/index.md
+++ b/content/en/fvm/reference/networks/index.md
@@ -36,7 +36,7 @@ The Wallaby test is intended to be used by:
 - Early builders from the community to test EVM smart contract deployment on FVM.
 - Early builders deploying native FVM actors.
 
-The Wallaby testnet is operated and maintained by [Factor8 Solutions](https://github.com/Factor8Solutions). You can find Wallaby-specific documentation written by Factor8 at [kb.factor8.io/en/docs/fil/wallabynet](https://kb.factor8.io/en/docs/fil/wallabynet).
+The Wallaby testnet is operated and maintained by [Factor8 Solutions](https://github.com/Factor8Solutions). You can find Wallaby-specific documentation written by Factor8 at [kb.factor8.dev/docs/filecoin/testnets/wallaby](https://kb.factor8.dev/docs/filecoin/testnets/wallaby).
 
 ## Block explorers
 


### PR DESCRIPTION
The Factor8 team moved their Wallaby docs to a new location. This PR updates our outbound links so they don't 404.