### PR TITLE
Adds legacy docs callout.

### DIFF
--- a/assets/scss/components/_alerts.scss
+++ b/assets/scss/components/_alerts.scss
@@ -42,6 +42,7 @@
 
 .alert a {
   text-decoration: underline;
+  color: $white;
 }
 
 .alert-primary .alert-link {

--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -73,9 +73,9 @@ footer_link = "https://protocol.ai"
 copyRight = ""
 
 # Alert
-alert = false
+alert = true
 alertDismissable = true
-alertText = ""
+alertText = "You can view the legacy version of this docs site at <a href='https://legacy-docs.filecoin.io'>legacy-docs.filecoin.io</a>."
 
 # Edit Page
 repoHost = "GitHub"


### PR DESCRIPTION
Adds a simple top alert telling the user that they can view the legacy docs at legacy-docs.filecoin.io. The alert can be closed for this browser session.

![Screen Shot 2022-12-20 at 1 59 22 PM](https://user-images.githubusercontent.com/9611008/208745146-4df4a49f-9d84-498d-a349-7e15499c8b42.png)

![Screen Shot 2022-12-20 at 1 59 31 PM](https://user-images.githubusercontent.com/9611008/208745161-67d0bec2-b741-4406-9563-6f09b1911850.png)
