### PR TITLE
Add/link to communit calendar

### DIFF
--- a/content/en/store/filecoin-plus/overview/index.md
+++ b/content/en/store/filecoin-plus/overview/index.md
@@ -143,6 +143,6 @@ There are a few different ways in which a client can find a storage provider to 
 If you are interested in participating in governance and shaping the program, here is how you can get involved:
 
 - Join the [#fil-plus](https://filecoinproject.slack.com/archives/C01DLAPKDGX) channel on Filecoin Slack.
-- Participate in Community Governance calls, which happen every other Tuesday. Use the [Filecoin Community Events Calendar](https://calendar.google.com/calendar/u/1?cid=Y19rMWdrZm9vbTE3ZzBqOGM2YmFtNnVmNDNqMEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t).
+- Participate in FIL notary community covernance calls, which happen every other Tuesday. Use the [Filecoin Community Events Calendar](https://calendar.google.com/calendar/u/1?cid=Y19rMWdrZm9vbTE3ZzBqOGM2YmFtNnVmNDNqMEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t).
 to join or watch for updates in #fil-plus
 - Create and comment on open issues in the [notary governance repo](https://github.com/filecoin-project/notary-governance/issues).

--- a/content/en/store/filecoin-plus/overview/index.md
+++ b/content/en/store/filecoin-plus/overview/index.md
@@ -142,6 +142,7 @@ There are a few different ways in which a client can find a storage provider to 
 
 If you are interested in participating in governance and shaping the program, here is how you can get involved:
 
-- Join the [#fil-plus](https://filecoinproject.slack.com/archives/C01DLAPKDGX) channel on Filecoin Slack
-- Participate in Community Governance calls, which happen every other Tuesday. Use the Filecoin Community Events calendar to join or watch for updates in #fil-plus
-- Create and comment on open issues in the [notary governance repo](https://github.com/filecoin-project/notary-governance/issues)
+- Join the [#fil-plus](https://filecoinproject.slack.com/archives/C01DLAPKDGX) channel on Filecoin Slack.
+- Participate in Community Governance calls, which happen every other Tuesday. Use the [Filecoin Community Events Calendar](https://calendar.google.com/calendar/u/1?cid=Y19rMWdrZm9vbTE3ZzBqOGM2YmFtNnVmNDNqMEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t).
+to join or watch for updates in #fil-plus
+- Create and comment on open issues in the [notary governance repo](https://github.com/filecoin-project/notary-governance/issues).


### PR DESCRIPTION
Replaces https://github.com/filecoin-project/filecoin-docs/pull/1488. Adds FIL notary community calendar to social links.