### PR TITLE
Replaces the Twitter icon with the Glossary icon.

### DIFF
--- a/config/_default/menus/menus.en.toml
+++ b/config/_default/menus/menus.en.toml
@@ -74,9 +74,9 @@
   weight = 10
 
 [[social]]
-  name = "Twitter"
-  pre = "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"20\" height=\"20\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\" class=\"feather feather-twitter\"><path d=\"M23 3a10.9 10.9 0 0 1-3.14 1.53 4.48 4.48 0 0 0-7.86 3v1A10.66 10.66 0 0 1 3 4s-4 9 5 13a11.64 11.64 0 0 1-7 2c9 5 20 0 20-11.5a4.5 4.5 0 0 0-.08-.83A7.72 7.72 0 0 0 23 3z\"></path></svg>"
-  url = "https://twitter.com/protocollabs"
+  name = "Glossary"
+  pre = '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-book"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"></path><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"></path></svg>'
+  url = "/glossary"
   weight = 20
 
 


### PR DESCRIPTION
Playing around with adding a Glossary link to the topbar nav so that readers can get to definitions faster. MIght not be necessary since we've got the tooltip feature now, but still might be useful.

<img width="1552" alt="Screen Shot 2022-12-26 at 8 02 23 PM" src="https://user-images.githubusercontent.com/9611008/209595381-4d5eb45f-79e1-4dfe-8ed3-5bf69eaf1dde.png">

The reason for replacing the Twitter icon is that I don't think it's used particularly often, nor does it add any significant value to the documentation. However, I have no data to back this up. We can probably put a counter on the Twitter icon to track how many clicks it gets a day.
