### PR TITLE
Fix/fvm root not redirecting

### DIFF
--- a/content/en/about/basics/what-is-filecoin/index.md
+++ b/content/en/about/basics/what-is-filecoin/index.md
@@ -17,8 +17,6 @@ aliases:
     - "/about-filecoin/what-is-filecoin"
 ---
 
-Filecoin is a peer-to-peer network that stores files, with built-in economic incentives to ensure files are stored reliably over time.
-
 In Filecoin, users pay to store their files on storage providers. Storage providers are computers responsible for storing files and proving they have stored the files correctly over time. Anyone who wants to store their files or get paid for storing other users’ files can join Filecoin. Available storage, and the price of that storage, is not controlled by any single company. Instead, Filecoin facilitates open markets for storing and retrieving files that anyone can participate in.
 
 Filecoin includes a blockchain and native cryptocurrency (FIL). Storage providers earn units of FIL for storing files. Filecoin’s blockchain records transactions to send and receive FIL, along with proofs from storage providers that they are storing their files correctly.

--- a/content/en/developers/smart-contracts/filecoin-virtual-machine/index.md
+++ b/content/en/developers/smart-contracts/filecoin-virtual-machine/index.md
@@ -13,6 +13,7 @@ weight: 3
 toc: true
 aliases:
     - "/fvm/basics/introduction/"
+    - "/fvm"
 ---
 
 {{< beta-warning >}}


### PR DESCRIPTION
Going to `filecoin.docs/fvm` shows an IPFS index page. This PR fixes that so users get directed to the proper FVM page.