### PR TITLE
Sets data access to draft.

### DIFF
--- a/content/en/developers/smart-contracts/concepts/data-access/index.md
+++ b/content/en/developers/smart-contracts/concepts/data-access/index.md
@@ -2,7 +2,7 @@
 title: "Data access"
 description: "The FVM enables developers to create applications that directly tie-into Filecoin's decentralized storage network. This page details how actors and contracts can access this data, and what they can do with it."
 lead: "The FVM enables developers to create applications that directly tie-into Filecoin's decentralized storage network. This page details how actors and contracts can access this data, and what they can do with it."
-draft: false
+draft: true
 images: []
 type: docs
 weight: 30


### PR DESCRIPTION
We don't have any content in data-access right now. Setting to draft so it doesn't show up in prod site.

Closes https://github.com/filecoin-project/filecoin-docs/issues/1601