### PR TITLE
smart-contracts/quickstart: change faucet value

### DIFF
--- a/content/en/developers/smart-contracts/quickstart/index.md
+++ b/content/en/developers/smart-contracts/quickstart/index.md
@@ -68,7 +68,7 @@ Nice! Now we've got the Filecoin Hyperspace testnet set up within MetaMask. You'
 1. Go to [hyperspace.yoga](https://hyperspace.yoga/#faucet) and scrolldown to the **Faucet** section.
 1. Paste your address into the address field, complete the **I am human** captcha, and then click **Send**:
 1. The faucet should give you a link to the transaction. Click it to view your transaction:
-1. The block explorer will show you the transaction history for your address. After a couple of minutes, you should see 5000 `tFIL` transferred to your address.
+1. The block explorer will show you the transaction history for your address. After a couple of minutes, you should see 5 `tFIL` transferred to your address.
 1. Open MetaMask to confirm that you received the `tFIL`:
 
 That's all there is to it! Getting `tFil` is easy!


### PR DESCRIPTION
5000 tFIL is changed to 5 tFIL, as indicated by the faucet page.