### PR TITLE
Address 2 css issues flagged by FF console

### DIFF
--- a/assets/scss/common/_global.scss
+++ b/assets/scss/common/_global.scss
@@ -261,10 +261,8 @@ body {
   background-image: linear-gradient(90deg, $primary, $blue-300 50%, $pink-500);
   background-size: 100%;
   background-repeat: repeat;
-  -webkit-background-clip: text;
-  -moz-background-clip: text;
+  background-clip: text;
   -webkit-text-fill-color: transparent;
-  -moz-text-fill-color: transparent;
 }
 
 .katex {


### PR DESCRIPTION
Fixes a few issues reported in https://github.com/filecoin-project/filecoin-docs/issues/1563

- use `background-clip`in place of` -moz-background-clip` and `-webkit-background-clip` since the latter two don't seem to exist / be supported (???)
- use `-webkit-text-fill-color` instead of ` -moz-text-fill-color`