### PR TITLE
Add 15px padding-bottom to mobile nav "on this page" dropdown

### DIFF
--- a/assets/scss/common/_global.scss
+++ b/assets/scss/common/_global.scss
@@ -288,3 +288,7 @@ body {
     opacity: 0;
   }
 }
+
+.d-xl-padding{
+  padding-bottom: 15px;
+}

--- a/layouts/docs/single.html
+++ b/layouts/docs/single.html
@@ -31,7 +31,7 @@
                 <p class="lead">{{ .Params.description }}</p>
             {{ end -}}
 			{{ if ne .Params.toc false -}}
-			<nav class="d-xl-none" aria-label="Quaternary navigation">
+			<nav class="d-xl-none" aria-label="Quaternary navigation" style="padding-bottom: 15px;">
 				{{ partial "sidebar/docs-toc.html" . }}
 			</nav>
 			{{ end -}}

--- a/layouts/docs/single.html
+++ b/layouts/docs/single.html
@@ -31,7 +31,7 @@
                 <p class="lead">{{ .Params.description }}</p>
             {{ end -}}
 			{{ if ne .Params.toc false -}}
-			<nav class="d-xl-none" aria-label="Quaternary navigation" style="padding-bottom: 15px;">
+			<nav class="d-xl-none d-xl-padding" aria-label="Quaternary navigation">
 				{{ partial "sidebar/docs-toc.html" . }}
 			</nav>
 			{{ end -}}


### PR DESCRIPTION
To address https://github.com/filecoin-project/filecoin-docs/issues/1648, set padding-bottom to 15px for the "on this page" dropdown that appears in mobile

Checkout the preview using the browser inspector to simulate the mobile view [here](https://bafybeihjnfr3x2cynje2vgbjolojeatvcug7sqackds2jkqb7equvwypzm.on.fleek.co/)