### PR TITLE
Update raw URLs where it makes sense

### DIFF
--- a/content/en/about/assets/wrapped-filecoin/index.md
+++ b/content/en/about/assets/wrapped-filecoin/index.md
@@ -45,10 +45,10 @@ There are several web-based applications for token wrapping. Here is an overview
 
 ## Wrapping solutions comparison table
 
-| **Name** | **Project** | **Infrastructure** | **Custodian** | **Main Blockchain**              | **Link**                            |
-|----------|-------------|--------------------|---------------|----------------------------------|-------------------------------------|
-| wFIL     | WRAPPED     | Centralized        | Anchorage     | Ethereum                         | https://www\.wrapped\.com/          |
-| BFIL     | Binance     | Centralized        | Binance       | Ethereum via Binance Token Canal | https://www\.binance\.com/          |
-| vFIL     | Venus       | Decentralized      | Decentralized | Binance Smart Chain              | https://www\.venus\.io/             |
-| eFIL     | Gemini      | Decentralized      | Gemini        | Ethereum                         | https://www\.gemini\.com/           |
-| HFIL     | Huobi       | Decentralized      | Huobi         | Ethereum                         | https://www\.huobi\.com             |
+| **Name** | **Project** | **Infrastructure** | **Custodian** | **Main Blockchain**              |
+|----------|-------------|--------------------|---------------|----------------------------------|
+| wFIL     | [WRAPPED](https://www.wrapped.com/)     | Centralized        | Anchorage     | Ethereum                         |
+| BFIL     | [Binance](https://www.binance.com/)     | Centralized        | Binance       | Ethereum via Binance Token Canal |
+| vFIL     | [Venus](https://www.venus.io/)          | Decentralized      | Decentralized | Binance Smart Chain              |
+| eFIL     | [Gemini](https://www.gemini.com/)       | Decentralized      | Gemini        | Ethereum                         |
+| HFIL     | [Huobi](https://www.huobi.com/)         | Decentralized      | Huobi         | Ethereum                         |

--- a/content/en/intro/intro-to-filecoin/blockchain/index.md
+++ b/content/en/intro/intro-to-filecoin/blockchain/index.md
@@ -57,9 +57,9 @@ Nodes in the Filecoin network are primarily identified in terms of the services 
 
 Filecoin is targeting multiple protocol implementations to guarantee the security and resilience of the Filecoin network. Currently, the actively maintained implementations are:
 
-- Lotus [lotus.filecoin.io/](https://lotus.filecoin.io/)
-- Venus [github.com/filecoin-project/venus](https://github.com/filecoin-project/venus)
-- Forest [github.com/ChainSafe/forest](https://github.com/ChainSafe/forest)
+- [Lotus](https://lotus.filecoin.io/)
+- [Venus](https://github.com/filecoin-project/venus)
+- [Forest](https://github.com/ChainSafe/forest)
 
 ## Addresses
 

--- a/content/en/intro/intro-to-filecoin/network/index.md
+++ b/content/en/intro/intro-to-filecoin/network/index.md
@@ -25,14 +25,14 @@ Test networks, or testnets, are version of the Filecoin network that attempt to 
 
 [Calibration](https://docs.filecoin.io/networks/overview/available-networks/%23calibration) testnet is the most realistic simulation of the mainnet, where prospective storage providers can experience more realistic sealing performance and hardware requirements due to the use of final proofs constructions and parameters, and prospective storage clients can store and retrieve real data on the network. Clients can participate in deal-making workflows and storage/retrieval functionality. It also has the same sector size as the mainnet.
 
-- Public endpoint: [https://api.calibration.node.glif.i](https://api.calibration.node.glif.io/rpc/v0)[o/rpc/v0](https://api.calibration.node.glif.io/rpc/v0)
-- Blockchain explorer: [https://calibration.filscan.io/](https://calibration.filscan.io/)
-- Faucet: [https://faucet.calibration.fildev.network/](https://faucet.calibration.fildev.network/)
+- [Public endpoint](https://api.calibration.node.glif.io/rpc/v0)
+- [Blockchain explorer](https://calibration.filscan.io/)
+- [Faucet](https://faucet.calibration.fildev.network/)
 
 ### Hyperspace
 
 [Hyperspace](https://github.com/filecoin-project/testnet-hyperspace) testnet is the main pre-production developer testnet which is more stable and reliable. The Hyperspace testnet is a pre-production developer-focused testnet. It resets only in the event of irrecoverable damage. Developers are welcome to build and test their toolings, applications, and smart contracts on this network.
 
-- Public endpoint: [https://api.hyperspace.node.glif.io/rpc/v0](https://api.hyperspace.node.glif.io/rpc/v0)
-- Blockchain explorer: [https://explorer.glif.io/?network=hyperspace](https://explorer.glif.io/?network%3Dhyperspace)
-- Faucet: [https://hyperspace.filtest.network/#faucet](https://hyperspace.filtest.network/%23faucet)
+- [Public endpoint](https://api.hyperspace.node.glif.io/rpc/v0)
+- [Blockchain explorer](https://explorer.glif.io/?network%3Dhyperspace)
+- [Faucet](https://hyperspace.filtest.network/%23faucet)

--- a/content/en/store/filecoin-plus/overview/index.md
+++ b/content/en/store/filecoin-plus/overview/index.md
@@ -48,9 +48,9 @@ Clients are required to have an on-chain Filecoin address where DataCap can be r
 
 _Note: As of network version 12, DataCap allocations are a single-use credit on a Filecoin address. If you receive an allocation and require more, you should make a new request with a unique address that you have initialized like above. [FIP-0012](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0012.md) was accepted and implemented in network version 13(actor v5), which allows client addresses to receive DataCap multiple times._
 
-Clients get DataCap by making a request to a notary. For your first DataCap allocation of 32GiB, you can use an auto-verifier such as https://verify.glif.io/. Auto-verifiers exist to grant DataCap immediately to clients that can authenticate themselves via a specific method. For example, the verify.glif.io automatic notary grants DataCap to clients who have a GitHub account that is > 180 days old and has not been used at this site in the past 30 days.
+Clients get DataCap by making a request to a notary. For your first DataCap allocation of 32GiB, you can use an auto-verifier such as [Verifier](https://verify.glif.io/). Auto-verifiers exist to grant DataCap immediately to clients that can authenticate themselves via a specific method. For example, the verify.glif.io automatic notary grants DataCap to clients who have a GitHub account that is > 180 days old and has not been used at this site in the past 30 days.
 
-1. Head over to https://verify.glif.io/
+1. Head over to [Verifier](https://verify.glif.io/)
 2. Connect your GitHub account - click the **Start** button on the top right of the page
 3. Sign in to GitHub if you have not already
 4. Paste in the address to which you'd like to receive DataCap in the box under "Request" and hit **Request**


### PR DESCRIPTION
Addresses https://github.com/filecoin-project/filecoin-docs/issues/1674

Updates raw URLs for:
```
content/en/about/assets/wrapped-filecoin/index.md
content/en/intro/intro-to-filecoin/blockchain/index.md
content/en/intro/intro-to-filecoin/network/index.md
content/en/store/filecoin-plus/overview/index.md
```

I ignored raw urls that were in code examples