### PR TITLE
Issue 1683 - Add Zondax libraries

### DIFF
--- a/content/en/developers/infrastructure/libraries/index.md
+++ b/content/en/developers/infrastructure/libraries/index.md
@@ -20,13 +20,13 @@ aliases:
 
 Zondax provides the [Filecoin Solidity npm package](#filecoin-solidity) and the [FEVM Precompiles library](#fevm-precompiles).
 
-### Filecoin Solidity
+## Filecoin.sol
 
 {{< alert >}}
 The Filecoin Solidity project is [currently in beta](https://docs.zondax.ch/fevm/filecoin-solidity#disclaimer-%EF%B8%8F%EF%B8%8F).
 {{< /alert >}}
 
-The _Filecoin Solidity_ npm package provides a set of Solidity libraries that allows Solidity smart contracts to seamlessly call Filecoin built-in actors methods, and perform cross-platform calls to the real Filecoin built-in actors. Additionally, a set of mock libraries that respond to specific scenarios is available. The scenarios are based on the received parameters instead of real calls. For further information, including information on how to use the package, see the [official documentation](https://docs.zondax.ch/fevm/filecoin-solidity/).
+_Filecoin.sol_ provides a set of libraries that allows Solidity smart contracts to seamlessly call built-in actors methods. Additionally, a set of mock libraries that respond to specific scenarios is available. The scenarios are based on the received parameters instead of real calls. For further information, including information on how to use the package, see the [official documentation](https://docs.zondax.ch/fevm/filecoin-solidity/).
 
 #### FEVM Precompiles
 

--- a/content/en/developers/infrastructure/libraries/index.md
+++ b/content/en/developers/infrastructure/libraries/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Libraries"
-description: "Certain libraries, software development kits (SDKs), and API clients exist to speed up the development of software on top of the Filecoin network. These assets provide a set of tools and resources that are tailored to Filecoin development, making it easier for developers to create high-quality applications quickly and efficiently."
-lead: "Certain libraries, software development kits (SDKs), and API clients exist to speed up the development of software on top of the Filecoin network. These assets provide a set of tools and resources that are tailored to Filecoin development, making it easier for developers to create high-quality applications quickly and efficiently."
+description: "Libraries, software development kits (SDKs), and API clients exist to speed up the development of software on top of the Filecoin network. These assets provide a set of tools and resources that are tailored to Filecoin development, making it easier for developers to create high-quality applications quickly and efficiently."
+lead: "Libraries, software development kits (SDKs), and API clients exist to speed up the development of software on top of the Filecoin network. These assets provide a set of tools and resources that are tailored to Filecoin development, making it easier for developers to create high-quality applications quickly and efficiently. The following libraries are currently available "
 draft: false
 images: []
 type: docs
@@ -15,3 +15,15 @@ aliases:
 ---
 
 {{< beta-warning >}}
+
+## Zondax 
+
+Zondax provides the [Filecoin Solidity npm package](#filecoin-solidity) and the [FEVM Precompiles library](#fevm-precompiles).
+
+### Filecoin Solidity
+
+The _Filecoin Solidity_ npm package provides a set of Solidity libraries that allows Solidity smart contracts to seamlessly call Filecoin built-in actors methods, and perform cross-platform calls to the real Filecoin built-in actors. Additionally, a set of mock libraries that respond to specific scenarios is available. The scenarios are based on the received parameters instead of real calls. For further, information, see the [official npm page](https://www.npmjs.com/package/@zondax/filecoin-solidity) and the [GitHub repository](https://github.com/Zondax/filecoin-solidity).
+
+#### FEVM Precompiles
+
+The FEVM Precompiles library provides a set of Solidity-compatible tools and libraries to enable Ethereum developers to develop Filecoin applications in the FVM Early Builder program. For further information, see the [GitHub repository](https://github.com/Zondax/fevm-solidity-precompiles/tree/main/docs/fevm-solidity-precompiles).

--- a/content/en/developers/infrastructure/libraries/index.md
+++ b/content/en/developers/infrastructure/libraries/index.md
@@ -22,7 +22,11 @@ Zondax provides the [Filecoin Solidity npm package](#filecoin-solidity) and the 
 
 ### Filecoin Solidity
 
-The _Filecoin Solidity_ npm package provides a set of Solidity libraries that allows Solidity smart contracts to seamlessly call Filecoin built-in actors methods, and perform cross-platform calls to the real Filecoin built-in actors. Additionally, a set of mock libraries that respond to specific scenarios is available. The scenarios are based on the received parameters instead of real calls. For further, information, see the [official npm page](https://www.npmjs.com/package/@zondax/filecoin-solidity) and the [GitHub repository](https://github.com/Zondax/filecoin-solidity).
+{{< alert >}}
+The Filecoin Solidity project is [currently in beta](https://docs.zondax.ch/fevm/filecoin-solidity#disclaimer-%EF%B8%8F%EF%B8%8F).
+{{< /alert >}}
+
+The _Filecoin Solidity_ npm package provides a set of Solidity libraries that allows Solidity smart contracts to seamlessly call Filecoin built-in actors methods, and perform cross-platform calls to the real Filecoin built-in actors. Additionally, a set of mock libraries that respond to specific scenarios is available. The scenarios are based on the received parameters instead of real calls. For further information, including information on how to use the package, see the [official documentation](https://docs.zondax.ch/fevm/filecoin-solidity/).
 
 #### FEVM Precompiles
 

--- a/content/en/developers/infrastructure/libraries/index.md
+++ b/content/en/developers/infrastructure/libraries/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Libraries"
-description: "Libraries, software development kits (SDKs), and API clients exist to speed up the development of software on top of the Filecoin network. These assets provide a set of tools and resources that are tailored to Filecoin development, making it easier for developers to create high-quality applications quickly and efficiently."
-lead: "Libraries, software development kits (SDKs), and API clients exist to speed up the development of software on top of the Filecoin network. These assets provide a set of tools and resources that are tailored to Filecoin development, making it easier for developers to create high-quality applications quickly and efficiently. The following libraries are currently available "
+description: "Libraries, software development kits (SDKs), API clients and tools exist to speed up the development of software on top of the Filecoin network. The available assets are listed on this page."
+lead: "Libraries, software development kits (SDKs), API clients and tools exist to speed up the development of software on top of the Filecoin network. The available assets are listed on this page."
 draft: false
 images: []
 type: docs
@@ -16,18 +16,24 @@ aliases:
 
 {{< beta-warning >}}
 
-## Zondax 
-
-Zondax provides the [Filecoin Solidity npm package](#filecoin-solidity) and the [FEVM Precompiles library](#fevm-precompiles).
-
 ## Filecoin.solidity
 
 {{< alert >}}
 The Filecoin Solidity project is [currently in beta](https://docs.zondax.ch/fevm/filecoin-solidity#disclaimer-%EF%B8%8F%EF%B8%8F).
 {{< /alert >}}
 
-_Filecoin.sol_ provides a set of libraries that allows Solidity smart contracts to seamlessly call built-in actors methods. Additionally, a set of mock libraries that respond to specific scenarios is available. The scenarios are based on the received parameters instead of real calls. For further information, including information on how to use the package, see the [official documentation](https://docs.zondax.ch/fevm/filecoin-solidity/).
+_Filecoin.solidity_ is a set of libraries that allows Solidity smart contracts to seamlessly call built-in actors methods. **Not all built-in actors and methods are supported - for a complete list, see the [actors and methods supported](https://docs.zondax.ch/fevm/filecoin-solidity/api/#actors-and-methods-supported). For further information, including information on how to use the package, see the [official documentation](https://docs.zondax.ch/fevm/filecoin-solidity/) and the [GitHub repository](https://github.com/Zondax/filecoin-solidity).
 
-#### FEVM Precompiles
+## Filecoin signing tools
 
-The FEVM Precompiles library provides a set of Solidity-compatible tools and libraries to enable Ethereum developers to develop Filecoin applications in the FVM Early Builder program. For further information, see the [GitHub repository](https://github.com/Zondax/fevm-solidity-precompiles/tree/main/docs/fevm-solidity-precompiles).
+The [Filecoin signing tools](https://github.com/Zondax/filecoin-signing-tools) provide basic functionality for signing Filecoin transactions in pure JavaScript, WASM and Rust. Currently, the Rust and WASM implementations support:
+
+- Secp256k1
+- BLS
+- CBOR-JSON serialization of transactions
+
+Support for multisignature transaction signing is currently in progress, and the pure JavaScript implementation is less complete than the Rust and WASM implementations. 
+
+## filecoin-address
+
+The _filecoin-address_ library is a JavaScript implementation of the Filecoin address type, and can create new address instances, encode addresses, and decode and validate checksums. For further information, including how to install and use, see the [GitHub repository](https://github.com/glifio/modules/tree/primary/packages/filecoin-address).

--- a/content/en/developers/infrastructure/libraries/index.md
+++ b/content/en/developers/infrastructure/libraries/index.md
@@ -20,7 +20,7 @@ aliases:
 
 Zondax provides the [Filecoin Solidity npm package](#filecoin-solidity) and the [FEVM Precompiles library](#fevm-precompiles).
 
-## Filecoin.sol
+## Filecoin.solidity
 
 {{< alert >}}
 The Filecoin Solidity project is [currently in beta](https://docs.zondax.ch/fevm/filecoin-solidity#disclaimer-%EF%B8%8F%EF%B8%8F).

--- a/content/en/developers/infrastructure/libraries/index.md
+++ b/content/en/developers/infrastructure/libraries/index.md
@@ -32,7 +32,7 @@ The [Filecoin signing tools](https://github.com/Zondax/filecoin-signing-tools) p
 - BLS
 - CBOR-JSON serialization of transactions
 
-Support for multisignature transaction signing is currently in progress, and the pure JavaScript implementation is less complete than the Rust and WASM implementations. 
+Support for multisignature transaction signing is currently in progress, and the pure JavaScript implementation is less complete than the Rust and WASM implementations. Learn more in the [official documentation](https://docs.zondax.ch/filecoin-signing-tools/).
 
 ## filecoin-address
 


### PR DESCRIPTION
Addresses https://github.com/filecoin-project/filecoin-docs/issues/1683

I used the info in https://github.com/filecoin-project/testnet-hyperspace#resources -> Filecoin Solidity libs. Based off that, looks like there's two Zondax libraries, Filecoin Solidity and FEVM Precompiles. Not sure if I misunderstood that

I should note that I am keeping descriptions intentionally short because it looks like both of these libraries are very much under development, so I'm just trying to give the reader the high level and then send them to the maintainers docs. Not sure if that fits the bill here, but that would be my recommendation 

*Blocker* 
The info on FEVM Precompiles is a bit hard to fill out based on https://github.com/Zondax/fevm-solidity-precompiles/tree/main/docs/fevm-solidity-precompiles... I'm really not clear what the status of this project is, as there README isn't even complete and there `docs` folder is hard to parse...