### PR TITLE
Adds a 'release on mainnet' shortcode.

### DIFF
--- a/content/en/intro/intro-to-filecoin/programming-on-filecoin/index.md
+++ b/content/en/intro/intro-to-filecoin/programming-on-filecoin/index.md
@@ -13,6 +13,8 @@ weight: 70
 toc: true
 ---
 
+{{< releasing-on-mainnet >}}
+
 ## Compute-over-data
 
 When it comes to data, a common need beyond storage and retrieval is data transformation. The goal with the compute-over-data protocols is generally to perform computation over [IPLD](https://youtu.be/Sgf6j_mCdjI), which is the data layer used by content-addressed systems like Filecoin. There are working groups working on different types of computing on Filecoin data, such as large-scale parallel compute (e.g., Bacalhau) and cryptographically verifiable compute (e.g. [Lurk](https://filecoin.io/blog/posts/introducing-lurk-a-programming-language-for-recursive-zk-snarks/)), etc.

--- a/layouts/shortcodes/releasing-on-mainnet.html
+++ b/layouts/shortcodes/releasing-on-mainnet.html
@@ -3,7 +3,7 @@
         ⚠️
     </div>
     <div class="w-100"> 
-        <p><strong>This will shortly be available on mainnet</strong></p>
+        <p><strong>This feature will be available on Filecoin Mainnet shortly.</strong></p>
         <p style="margin-bottom: 0px;">This feature relies on the <a href="/intro/intro-to-filecoin/programming-on-filecoin/#filecoin-virtual-machine">Filecoin EVM runtime</a>. It will become available on mainnet starting March 14th, 2023, with the <a href="https://github.com/filecoin-project/lotus/discussions/10219">Hygge NV18 upgrade</a>.</p>
     </div>
 </div>

--- a/layouts/shortcodes/releasing-on-mainnet.html
+++ b/layouts/shortcodes/releasing-on-mainnet.html
@@ -1,0 +1,9 @@
+<div class="alert alert-warning d-flex" role="alert">
+    <div class="flex-shrink-1 alert-icon">
+        ⚠️
+    </div>
+    <div class="w-100"> 
+        <p><strong>This will shortly be available on mainnet</strong></p>
+        <p style="margin-bottom: 0px;">This feature relies on the <a href="/intro/intro-to-filecoin/programming-on-filecoin/#filecoin-virtual-machine">Filecoin EVM runtime</a>. It will become available on mainnet starting March 14th, 2023, with the <a href="https://github.com/filecoin-project/lotus/discussions/10219">Hygge NV18 upgrade</a>.</p>
+    </div>
+</div>


### PR DESCRIPTION
This PR adds a _this isn't available on mainnet yet but will be as on March 14th_ shortcode. This shortcode can be added to pages where the features aren't yet available on mainnet.

To use this shortcode enter `{{< releasing-on-mainnet >}}` within the markdown. For example:

```markdown
...

weight: 70
toc: true
---

{{< releasing-on-mainnet >}}

## Compute-over-data

...
```

The benefit of using this shortcode is that we can quickly delete it after nv18 upgrade.


<img width="1054" alt="Screen Shot 2023-02-27 at 9 27 36 PM" src="https://user-images.githubusercontent.com/9611008/221728876-8c89fb2e-7c59-46ba-9ac5-9d6e1eb439b9.png">
