### PR TITLE
fix: get test tokens

### DIFF
--- a/content/en/developers/smart-contracts/how-tos/get-test-tokens/index.md
+++ b/content/en/developers/smart-contracts/how-tos/get-test-tokens/index.md
@@ -100,4 +100,4 @@ Before we begin, you must have a local testnet running. Follow the [Run a local 
     2000 FIL
     ```
 
-If you want to manage your local testnet tokens in MetaMask you will need to create a `t4` address. You can create a `t4` address using `lotus wallet new deleated`. Once you have a `t4` address you can [connect MetaMask to your local testnet]({{< relref "add-to-metamask" >}}) to see the new balance within the MetaMask extension.
+If you want to manage your local testnet tokens in MetaMask you will need to create a `t4` address. You can create a `t4` address using `lotus wallet new delegated`. Once you have a `t4` address you can [connect MetaMask to your local testnet]({{< relref "add-to-metamask" >}}) to see the new balance within the MetaMask extension.


### PR DESCRIPTION
Fix the spelling mistake in the lotus command for creating an f4 wallet.