### PR TITLE
issue-1796:update node service providers detail

### DIFF
--- a/content/en/networks/hyperspace/rpcs/index.md
+++ b/content/en/networks/hyperspace/rpcs/index.md
@@ -25,8 +25,8 @@ These endpoints are limited to all read-only Filecoin JSON RPC API calls and `MP
 
 ## [ChainStack](https://chainstack.com/labs/#filecoin)
 
-- HTTPS: `https://filecoin-hyperspace.chainstacklabs.com/rpc/v0`
-- WebSockets: `wss://ws-filecoin-hyperspace.chainstacklabs.com/rpc/v0`
+- HTTPS: `https://filecoin-hyperspace.chainstacklabs.com/rpc/v1`
+- WebSockets: `wss://ws-filecoin-hyperspace.chainstacklabs.com/rpc/v1`
 
 ## [Ankr](https://ankr.com)
 

--- a/content/en/networks/mainnet/rpcs/index.md
+++ b/content/en/networks/mainnet/rpcs/index.md
@@ -13,7 +13,23 @@ weight: 130
 toc: true
 ---
 
+## [Glif](https://glif.io)
+
+Please note that a publicly available hosted endpoint guarantees **only 2000 of the latest blocks.**
+
+- HTTPS: `https://api.node.glif.io/rpc/v1`
+
+- WebSockets: `wss://wss.hyperspace.node.glif.io/apigw/lotus/rpc/v1`
+
+- Lotus lite-node command
+
+  ```shell
+  FULLNODE_API_INFO=wss://wss.node.glif.io/apigw/lotus lotus daemon --lite
+  ```
+
+- [Glif Node documentation](https://hosting.glif.io/)
+
 ## [Ankr](https://ankr.com)
 
-- HTTPS: `https://rpc.ankr.com/filecoin_testnet`
-- [Ankr documentation](https://www.ankr.com/docs/rpc-service/chains/chains-list/#filecoin)
+- HTTPS: `https://rpc.ankr.com/filecoin`
+- [Supported Filecoin API methods](https://www.ankr.com/docs/rpc-service/chains/chains-list/#filecoin)


### PR DESCRIPTION
Close #1796 .

- [x] Add Mainnet node provider details for Glif & Ankr. 
- [x] Test the endpoint, works fine.

Did not find anything from ChainStack and I think they are not ready at this moment. 