### PR TITLE
Remove Fuhon in /reference/json-rpc/introduction/

### DIFF
--- a/content/en/reference/json-rpc/introduction/index.md
+++ b/content/en/reference/json-rpc/introduction/index.md
@@ -91,6 +91,5 @@ Each node implementation has different ways to generate and manage authenticatio
 
 - [Lotus](https://lotus.filecoin.io)
 - [Venus](https://venus.filecoin.io)
-- [Fuhon](https://github.com/filecoin-project/cpp-filecoin)
 
 If you are using a node provider service like [Glif](https://glif.io) or [Chain.love](https://chain.love), take a look at your providers documentation to find out how to manage authentication tokens.


### PR DESCRIPTION
Addresses https://github.com/filecoin-project/filecoin-docs/issues/1819

Removes Fuhon from list of nodes in /reference/json-rpc/introduction/