### PR TITLE
Expand on lassie & go-car docs, demonstrate one-line form

### DIFF
--- a/content/en/basics/how-retrieval-works/basic-retrieval/index.md
+++ b/content/en/basics/how-retrieval-works/basic-retrieval/index.md
@@ -17,7 +17,7 @@ aliases:
 
 ## Lassie
 
-Lassie is a simple retrieval client for Filecoin. It finds and fetches your data over the best retrieval protocols available.
+Lassie is a simple retrieval client for Filecoin and IPFS. It finds and fetches your data over the best retrieval protocols available.
 
 ### Prerequisites
 
@@ -38,8 +38,9 @@ Make sure that you have [Go](https://go.dev/) installed and that your `GOPATH` i
 
     ...
     ```
+    Lassie fetches content in content-addressed archive (CAR) form, so in most cases you will need additional tooling to deal with CAR files.
 
-1. Install the [go-car](https://github.com/ipld/go-car) package using the Go package manager:
+2. Install the [go-car](https://github.com/ipld/go-car) package using the Go package manager:
 
     ```shell
     go install github.com/ipld/go-car/cmd/car@latest
@@ -53,25 +54,59 @@ Make sure that you have [Go](https://go.dev/) installed and that your `GOPATH` i
     ...
     ```
 
-    The go-car package makes it easier to work with content-addressed archive (CAR) files.
+    The go-car package makes it easier to work with content-addressed archives (CAR).
 
-You now have everything you need to retrieve a file with Lassie and extract the contents with Go-car.
+You now have everything you need to retrieve a file with Lassie and extract the contents with go-car.
 
-### Retrieve
+### Retrieve and extract
 
-To retrieve data from Filecoin using Lassie, all you need is the CID of the content you want to download. You can use the following CIDs to test the process:
+Lassie and go-car can work together to retrieve and extract data from Filecoin, all you need is the CID of the content to download.
 
-1. The format for retrieving data using Lassie is:
+```shell
+lassie fetch -o - <CID> | car extract
+```
 
-    ```shell
-    lassie fetch -o <OUTFILE_FILE_NAME> -p <CID>
-    ```
+This command uses a `|` to chain two commands together, this will work on Linux or a macOS. Windows users may need to use PowerShell to use this form. Alternatively, you can use the commands separately as explained later in this page.
+
+An example of fetching and extracting a single file, identified by its CID:
+
+```shell
+lassie fetch -o - bafykbzaceatihez66rzmzuvfx5nqqik73hlphem3dvagmixmay3arvqd66ng6 | car extract - > lidar-data.tar
+```
+
+Will output basic progress information:
+
+```plaintext
+Fetching bafykbzaceatihez66rzmzuvfx5nqqik73hlphem3dvagmixmay3arvqd66ng6................................................................................................................................................
+Fetched [bafykbzaceatihez66rzmzuvfx5nqqik73hlphem3dvagmixmay3arvqd66ng6] from [12D3KooWPNbkEgjdBNeaCGpsgCrPRETe4uBZf1ShFXStobdN18ys]:
+        Duration: 42.259908785s
+          Blocks: 144
+           Bytes: 143 MiB
+extracted 1 file(s)
+```
+
+The resulting file is a tar archive:
+
+```shell
+ls -l
+```
+
+```shell
+total 143M
+-rw-rw-r-- 1 user user 143M Feb 16 11:21 lidar-data.tar
+```
+
+### Lassie CLI usage
+
+Lassie usage for retrieving data is:
+
+```shell
+lassie fetch -p -o <OUTFILE_FILE_NAME> <CID>/path/to/content
+```
+
+* `-p` is an optional flag that tells Lassie that you would like to see detailed progress information as it fetches your data.
 
     For example:
-
-    ```shell
-    lassie fetch -o output.car -p bafykbzaceatihez66rzmzuvfx5nqqik73hlphem3dvagmixmay3arvqd66ng6
-    ```
 
     ```plaintext
     Fetching bafykbzaceatihez66rzmzuvfx5nqqik73hlphem3dvagmixmay3arvqd66ng6
@@ -87,47 +122,33 @@ To retrieve data from Filecoin using Lassie, all you need is the CID of the cont
     ...
     ```
 
-1. This will create an `output.car` file within your current directory:
+* `-o` is an optional flag that tells Lassie where to write the output to. If you don't specify a file, it will append `.car` to your CID and use that as the output file name.
 
-    ```shell
-    ls -l
-    ```
+    If you specify `-`, as in our above example, the output will be written to stdout so it can be piped to another command, such as go-car, or redirected to a file.
 
-    ```shell
-    total 143M
-    -rw-rw-r-- 1 user user 143M Feb 16 11:21 output.car
-    ```
+* `<CID>/path/to/content` is the CID of the content you want to retrieve, and an optional path to a specific file within that content.
 
-### Extract data
+    A CID is always necessary and if you don't specify a path, Lassie will attempt to download the entire content. If you specify a path, Lassie will only download that specific file, or if it is a directory, the entire directory and its contents.
 
-Now that we’ve downloaded a CAR file, we need to find out what’s inside it. 
+### go-car CLI usage
 
-1. The format for extracting a `.car` file using Go-car is:
+The `car extract` command can be used to extract files and directories from a CAR:
 
-    ```shell
-    car extract --file <INPUT_FILE>
-    ```
+```shell
+car extract -f <INPUT_FILE>[/path/to/file/or/directory] [<OUTPUT_DIR>]
+```
 
-1. Extract the `output.car` file we just downloaded using Lassie:
+* `-f` is an optional flag that tells go-car where to read the input from. If omitted, it will read from stdin, as in our example above where we piped `lassie fetch -o -` output to `car extract`.
 
-    ```shell
-    car extract --file output.car
-    ```
+* `/path/to/file/or/directory` is an optional path to a specific file or directory within the CAR. If omitted, it will attempt to extract the entire CAR.
 
-    This command does not output anything on success.
+* `<OUTPUT_DIR>` is an optional argument that tells go-car where to write the output to. If omitted, it will write to the current directory.
 
-1. You can list the output of the `car` command with `ls`:
+    If you supply `-`, as in the above example, it will attempt to extract the content directly to stdout. This will only work if we are extracting a single file.
 
-    ```shell
-    ls -lh
-    ```
+    In our above example, we used the `>` operator to redirect the output of `car extract` to a named file, this is because the content we fetched was raw file data, that did not have a name encoded. In this case, if we didn't use `-` and `> filename`, go-car would write to a file named `unknown`.
 
-    ```plaintext
-    -rw-rw-r-- 1 user user 143M Feb 16 11:21 output.car
-    -rw-rw-r-- 1 user user 143M Feb 16 11:36 moon-data.tar.gz
-    ```
-
-1. You can then manage the data as you need.
+go-car has some other useful commands, such as `car ls` which can be used to list the contents of a CAR, and `car inspect` which can be used to inspect the contents of the CAR, and optionally verify the integrity of a CAR.
 
 And there we have it! Downloading and managing data from Filecoin is super simple when you use Lassie and Go-car!
 


### PR DESCRIPTION
Is this too wordy and advanced? The main goal here is to demonstrate the compact form `lassie fetch -o - <CID> | car extract`, but there's a lot more that can be said about what you can do.

I'm also conscious that this is very file focused. That serves the 95% use case so I'm guessing that's fine, but `car extract` is for UnixFS data only. Hopefully if you're not doing UnixFS data then you at least have a clue.