### PR TITLE
Chore/fix formatting in address types

### DIFF
--- a/content/en/smart-contracts/filecoin-evm-runtime/address-types/index.md
+++ b/content/en/smart-contracts/filecoin-evm-runtime/address-types/index.md
@@ -144,7 +144,7 @@ Again, assume you have deployed a solidity smart contract on Filecoin Hyperspace
 
 When you try to invoke this smart contract on Filecoin using Ethereum toolings, you need to use your `0x5f6044198a16279f87d2839c998893858bbf8d9c` smart contract address.
 
-## Converting to a 0x-style address
+### Converting to a 0x-style address
 
 The Filecoin EVM runtime introduces support for `0x` Ethereum-style addresses. Filecoin addresses starting with either `f0` or `f410f` can be converted to the `0x` format as follows:
 

--- a/content/en/smart-contracts/filecoin-evm-runtime/address-types/index.md
+++ b/content/en/smart-contracts/filecoin-evm-runtime/address-types/index.md
@@ -13,7 +13,7 @@ weight: 210
 toc: true
 ---
 
-Filecoin has 5 address classes and actors tend to have *multiple* addresses. Furthermore, each address class has its own rules for converting between binary and text.
+Filecoin has five address classes, and actors tend to have *multiple* addresses. Furthermore, each address class has its own rules for converting between binary and text.
 
 The goal of using different types of addresses is to provide a robust address format that is scalable, easy to use, and reliable. These addresses encode information including：
 
@@ -22,7 +22,7 @@ The goal of using different types of addresses is to provide a robust address fo
 - Payload: identify the actor according to the protocol.
 - Checksum: validate the address.
 
-Filecoin addresses can be represented either as raw bytes or a string. Raw bytes format will be always used on-chain. An address can be also encoded to a string including a checksum and network prefix. The string format will never appear on-chain, and is only for human-readable purposes.
+Filecoin addresses can be represented either as raw bytes or a string. Raw bytes format will always be used on-chain. An address can also be encoded to a string, including a checksum and network prefix. The string format will never appear on-chain and is only for human-readable purposes.
 
 Filecoin address can be broken down like this:
 
@@ -30,19 +30,19 @@ Filecoin address can be broken down like this:
 | -------------- | ----------------------------------- | ------- | -------- |
 | `f` / `t`      | 1 byte: `0` / `1` / `2` / `3` / `4` | _n_ bytes | 4 bytes  |
 
-The network prefix is prepended to an address when encoding to a string. The network prefix indicates which network an address belongs to. Network prefixes never appear on-chain, and are only used when encoding an address to a human-readable format.
+The network prefix is prepended to an address when encoding to a string. The network prefix indicates which network an address belongs to. Network prefixes never appear on-chain and are only used when encoding an address to a human-readable format.
 
 - `f` - addresses on the  Filecoin mainnet.
 - `t` - addresses used on any Filecoin testnet.
 
-The protocol indicator identifies the address type which describes how a method should interpret the information in the `payload` field of an address.
+The protocol indicator identifies the address type, which describes how a method should interpret the information in the `payload` field of an address.
 
 - `0`: An ID address.
 - `1`: A wallet address generated from a secp256k public key.
 - `2`: An actor address.
 - `3`: A wallet address generated from BLS public key.
 - `4`: A delegated address for user-defined foreign actors:
-    - `410`: Ethereum compatible address space managed by the Ethereum Address Manager (EAM).
+    - `410`: Ethereum-compatible address space managed by the Ethereum Address Manager (EAM).
 
 Each address type is described below.
 
@@ -102,7 +102,7 @@ t 410 iandfn6d...
 Network identifier
 ```
 
-The _address manager actor ID_ is the actor ID of the address manager actor which creates new actors and assigns a `4` address to the new actor. This leverages the extensible feature of the `f4` address class.
+The _address manager actor ID_ is the actor ID of the address manager actor, which creates new actors and assigns a `4` address to the new actor. This leverages the extensible feature of the `f4` address class.
 
 The _new actor ID_ is the arbitrary actor ID chosen by that actor.  
 
@@ -110,13 +110,13 @@ The _new actor ID_ is the arbitrary actor ID chosen by that actor.
 
 Currently, per [fip-0048](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0048.md), `f4` addresses may only be assigned by and in association with specific, built-in actors called _address managers_. This restriction will likely be relaxed once users are able to deploy custom WebAssembly actors.
 
-This address type plays a very essential role in supporting the EVM-compatible FVM. It allows the Filecoin network to be able to recognize the foreign address and validate and execute the transactions sent and signed by the supported foreign addresses.
+This address type plays an essential role in supporting the EVM-compatible FVM. It allows the Filecoin network to be able to recognize the foreign address and validate and execute the transactions sent and signed by the supported foreign addresses.
 
 The supported foreign addresses can be cast as `f4/t4` addresses, and vice-versa.  But not with `f1/t1` or `f3/t3` addresses.
 
 ### Ethereum Address Manager
 
-Ethereum Address Manager (EAM) is a built-in actor which manages the Ethereum address space, anchored at the `410` address namespace. It acts like an EVM smart contract factory, offering methods to create and assign the `f410/t410` Filecoin address to Ethereum address.
+Ethereum Address Manager (EAM) is a built-in actor that manages the Ethereum address space, anchored at the `410` address namespace. It acts like an EVM smart contract factory, offering methods to create and assign the `f410/t410` Filecoin address to Ethereum address.
 
 The subaddress of an `f410/t410` address is the original Ethereum address. Ethereum addresses can be cast as `f410` addresses, and vice-versa. The `f410/t410` address will be used for the Ethereum-compatible FVM (FEVM) development tools and applications built on FEVM.
 
@@ -130,7 +130,7 @@ The subaddress of an `f410/t410` address is the original Ethereum address. Ether
 t410f2oekwcmo2pueydmaq53eic2i62crtbeyuzx2gmy
 ```
 
-If you have an Ethereum wallet address starting with `0x` , then the Ethereum Address Manager (EAM) will assign a corresponding `t410` Filecoin address to it. If you send 10 TFIL to `0xd388ab098ed3e84c0d808776440b48f685198498` address using a wallet like MetaMask, you will receive 10 TFIL to your `t410f2oekwcmo2pueydmaq53eic2i62crtbeyuzx2gmy` address on Filecoin Hyperspace testnet.
+If you have an Ethereum wallet address starting with `0x`, then the Ethereum Address Manager (EAM) will assign a corresponding `t410` Filecoin address to it. If you send 10 TFIL to `0xd388ab098ed3e84c0d808776440b48f685198498` using a wallet like MetaMask, you will receive 10 TFIL to your `t410f2oekwcmo2pueydmaq53eic2i62crtbeyuzx2gmy` address on Filecoin Hyperspace testnet.
 
 ```plaintext
 # A Filecoin smart contract address.
@@ -148,17 +148,17 @@ When you try to invoke this smart contract on Filecoin using Ethereum toolings, 
 
 The Filecoin EVM runtime introduces support for `0x` Ethereum-style addresses. Filecoin addresses starting with either `f0` or `f410f` can be converted to the `0x` format as follows:
 
-Addresses starting with `f0` address can be converted to the `0x` format by:
+Addresses starting with `f0` can be converted to the `0x` format by:
 - Extracting the `actor_id` (e.g., the `1234` in `f01234`).
 - Hex encode with a `0xff` prefix: `sprintf("0xff0000000000000000000000%016x", actor_id)`.
 
 Addresses starting with `f410f` address can be converted to the `0x`  format by:
 - Removing the `f410f` prefix.
-- Decoding the remainder as base32 (RFC 4648 without padding).
+- Decoding the remainder as base 32 (RFC 4648 without padding).
 - Trim off the last 4 bytes. This is a _checksum_ that can optionally be verified, but that's beyond the scope of this documentation.
 - Assert that the remaining address is 20 bytes long.
 - Hex-encode: `sprintf(0x%040x", actor_id)`.
 
 {{< alert >}}
-⚠️ Remember that `f0` addresses are **not** re-org stable and should not be used until the chain has settled.
+⚠️ `f0` addresses are **not** re-org stable and should not be used until the chain has settled.
 {{< /alert >}}


### PR DESCRIPTION
Minor fixes to the Smart Contract Address Types page. Mainly grammar, spelling, and formatting changes.