### PR TITLE
Removes GA.

### DIFF
--- a/layouts/partials/head/script-header.html
+++ b/layouts/partials/head/script-header.html
@@ -7,15 +7,6 @@
   <script>{{ $alertInit.Content | safeJS }}</script>
 {{- end -}}
 
-<!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-H3D2P5EGFR"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-H3D2P5EGFR');
-</script>
 <script defer data-domain="docs.filecoin.io" src="https://plausible.io/js/plausible.js"></script>
 
 <!-- Swiftype -->


### PR DESCRIPTION
Not sure why I named this branch _privacy invading ..._ but it'll do. This PR removes Google Analytics from the website. We use [Plausible instead](https://plausible.io/docs.filecoin.io). Closes [1822](https://github.com/filecoin-project/filecoin-docs/issues/1822) https://github.com/filecoin-project/filecoin-docs/issues/1855 