### PR TITLE
Added global button style that matches the homepage style

### DIFF
--- a/assets/scss/components/_buttons.scss
+++ b/assets/scss/components/_buttons.scss
@@ -1,3 +1,18 @@
+button {
+  background: $blue-400;
+  color: $white;
+  padding: 12px 24px;
+  border-radius: 8px;
+  transition: background-color 200ms ease;
+  border: none;
+}
+
+button:hover {
+  color: $white;
+  text-decoration: none;
+  background-color: $blue-500;
+}
+
 .navbar .btn-link {
   color: $navbar-light-color;
   padding: 0.4375rem 0;

--- a/layouts/shortcodes/button.html
+++ b/layouts/shortcodes/button.html
@@ -1,0 +1,3 @@
+<a href="{{ .Get "url" }}" class="{{ .Get "class" }}">
+    <button>{{.Inner}}</button>
+</a>


### PR DESCRIPTION
Added a global button style so that when its used from an .md file , it would always use the same button style throughout the docs. 

example:
<img width="1424" alt="Screen Shot 2023-03-29 at 11 35 52 AM" src="https://user-images.githubusercontent.com/28320272/228591523-82058ab5-e87f-4bdc-91dd-9171102e440a.png">

<img width="1424" alt="Screen Shot 2023-03-29 at 11 36 20 AM" src="https://user-images.githubusercontent.com/28320272/228591647-e84686c7-0bf3-4a7e-8b21-9ec53d1d3e65.png">

this way works too:
<img width="1366" alt="Screen Shot 2023-03-29 at 11 16 50 AM" src="https://user-images.githubusercontent.com/28320272/228591988-e0ea0e2f-c9a8-4398-a089-23864ee305d8.png">
<img width="817" alt="Screen Shot 2023-03-29 at 11 30 34 AM (1)" src="https://user-images.githubusercontent.com/28320272/228592165-6dc5646e-b2f7-4c3f-81dc-70ea6b8e6f82.png">


