### PR TITLE
Remove {{< releasing-on-mainnet >}} banner

### DIFF
--- a/content/en/basics/what-is-filecoin/programming-on-filecoin/index.md
+++ b/content/en/basics/what-is-filecoin/programming-on-filecoin/index.md
@@ -15,8 +15,6 @@ aliases:
     - "/intro/intro-to-filecoin/programming-on-filecoin/"
 ---
 
-{{< releasing-on-mainnet >}}
-
 ## Compute-over-data
 
 When it comes to data, a common need beyond storage and retrieval is data transformation. The goal with the compute-over-data protocols is generally to perform computation over [IPLD](https://youtu.be/Sgf6j_mCdjI), which is the data layer used by content-addressed systems like Filecoin. There are working groups working on different types of computing on Filecoin data, such as large-scale parallel compute (e.g., Bacalhau) and cryptographically verifiable compute (e.g. [Lurk](https://filecoin.io/blog/posts/introducing-lurk-a-programming-language-for-recursive-zk-snarks/)), etc.


### PR DESCRIPTION
https://docs.filecoin.io/basics/what-is-filecoin/programming-on-filecoin/ is still showing the `{{< releasing-on-mainnet >}}` banner
```
This feature will be available on Filecoin Mainnet shortly.

This feature relies on the Filecoin EVM runtime. It will become available on mainnet starting March 14th, 2023, with the Hygge NV18 upgrade.
```