### PR TITLE
Keeps topbar items bolded, even when they're dropdowns.

### DIFF
--- a/config/_default/menus/menus.en.toml
+++ b/config/_default/menus/menus.en.toml
@@ -20,7 +20,7 @@
   identifier= "main-nodes"
 
 [[main]]
-  name = "Smart contracts"
+  name = "Smart Contracts"
   url = "/smart-contracts/fundamentals/the-filecoin-virtual-machine/"
   weight = 40
   identifier= "main-smart-contracts"

--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -64,7 +64,7 @@
             {{- $active = or $active (and (eq .Name "Blog") (eq $current.Section "blog" "authors")) -}}
             {{ if .HasChildren }}
               <li class="nav-item dropdown">
-                <a class="nav-link dropdown-toggle ps-0 py-1" href="#" id="navbarDropdownMenuLink" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                <a class="nav-link dropdown-toggle ps-0 py-1 {{ if $active }} active{{ end }} " href="#" id="navbarDropdownMenuLink" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                   {{ .Name }}
                   <span class="dropdown-caret"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-chevron-down"><polyline points="6 9 12 15 18 9"></polyline></svg></span>
                 </a>

--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -54,8 +54,14 @@
           {{ range .Site.Menus.main -}}
             {{- $active := or ($current.IsMenuCurrent "main" .) ($current.HasMenuCurrent "main" .) -}}
             {{- $active = or $active (eq .Name $current.Title) -}}
-            {{- $active = or $active (and (eq .Name ($section | humanize)) (eq $current.Section $section)) -}}
-            {{- $active = or $active (and (eq .Name "Blog") (eq $current.Section "blog" "contributors" "categories" "tags")) -}}
+            {{- $active = or $active (and (eq .Name "Basics") (eq $current.Section "basics")) -}}
+            {{- $active = or $active (and (eq .Name "Store") (eq $current.Section "store")) -}}
+            {{- $active = or $active (and (eq .Name "Storage Providers") (eq $current.Section "storage-provider")) -}}
+            {{- $active = or $active (and (eq .Name "Nodes") (eq $current.Section "nodes")) -}}
+            {{- $active = or $active (and (eq .Name "Smart Contracts") (eq $current.Section "smart-contracts")) -}}
+            {{- $active = or $active (and (eq .Name "Networks") (eq $current.Section "networks")) -}}
+            {{- $active = or $active (and (eq .Name "Reference") (eq $current.Section "reference")) -}}
+            {{- $active = or $active (and (eq .Name "Blog") (eq $current.Section "blog" "authors")) -}}
             {{ if .HasChildren }}
               <li class="nav-item dropdown">
                 <a class="nav-link dropdown-toggle ps-0 py-1" href="#" id="navbarDropdownMenuLink" role="button" data-bs-toggle="dropdown" aria-expanded="false">


### PR DESCRIPTION
A bug in the current Filecoin docs causes the topbar items to _not_ be bolded when:

- The item contains an empty space.
- The item doesn't match the directory name.
- The item is a dropdown.

For example, _Storage providers_ is not bolded when in the `storage-provider` section:

![Screenshot 2023-04-12 at 09 34 55](https://user-images.githubusercontent.com/9611008/231458696-3b693245-7856-48e1-8b4b-2eaf4670ed5e.png)

This PR fixes this issue by:

- Hardcoding the names and directories of each topbar menu.
- Adding logic to add the `active` class on any topbar menu item, even if it's a dropdown.

![Screenshot 2023-04-12 at 09 33 48](https://user-images.githubusercontent.com/9611008/231458404-1c04dafc-26f8-44c7-b5da-6fa9ee64f339.png)

This PR also changed the topbar item of *Smart contracts* to *Smart Contracts*.

## Test

This branch was initially started as a test to see if this was possible to fix. Turns out it was possible to fix, leading to the strange branch name.