### PR TITLE
fix(docs): missing closing parenthesis

### DIFF
--- a/content/en/basics/what-is-filecoin/networks/index.md
+++ b/content/en/basics/what-is-filecoin/networks/index.md
@@ -29,7 +29,7 @@ Test networks, or testnets, are version of the Filecoin network that attempt to 
 
 - [Public endpoint](https://api.calibration.node.glif.io/rpc/v0)
 - [Blockchain explorer](https://calibration.filscan.io/)
-- [Faucet](https://faucet.calibration.fildev.network/
+- [Faucet](https://faucet.calibration.fildev.network/)
 
 ### Spacenet
 


### PR DESCRIPTION
The Calibration network faucet link is broken due to the lack of a closing parenthesis.