### PR TITLE
Added Image With Text Component to the documentation

### DIFF
--- a/layouts/shortcodes/imageWithText.html
+++ b/layouts/shortcodes/imageWithText.html
@@ -1,0 +1,15 @@
+<div
+  class="image-with-text"
+  style="display: flex; align-items: center; justify-content: flex-start"
+>
+  {{ with .Get "src" }}
+  <img
+    class="image-with-text-image"
+    style="height: 3rem"
+    src="{{ . }}"
+    alt="{{ . }}"
+  />
+  {{ end }} {{ with .Get "title" }}
+  <h2 class="image-with-text-title">{{ . }}</h2>
+  {{ end }}
+</div>


### PR DESCRIPTION
Ivanka Majic ( User Researcher at PLN) requested to have a component with an image/icon next to a title. 

This component allows accessing this ability by going into any .md file and using : 
`{{< imageWithText title="Beautiful Landscape" src="https://cdn-icons-png.flaticon.com/512/4874/4874623.png" >}}`


# Preview
<img width="1222" alt="Screen Shot 2023-06-21 at 12 26 13 PM" src="https://github.com/filecoin-project/filecoin-docs/assets/28320272/c96b17e5-cd6d-4968-a347-496efa768e37">
<img width="1237" alt="Screen Shot 2023-06-21 at 6 28 13 PM" src="https://github.com/filecoin-project/filecoin-docs/assets/28320272/6d6a657b-94f0-46d1-b308-f0b703be00c1">

