### PR TITLE
Patches pre commit script

### DIFF
--- a/pre-commit-lint.sh
+++ b/pre-commit-lint.sh
@@ -32,21 +32,21 @@ if [ ${#mdFileList} -gt 0 ]; then
     echo $regularBar
     echo "${bold}Spell check${normal}"
     echo $regularBar
-    npx mdspell -r -a -n --en-us ${mdFileList[*]} "$@"
+    npx mdspell -r -a -n --en-us $mdFileList "$@"
     spellPassed=$?
 
     echo " "
     echo $regularBar
     echo "${bold}Link check${normal}"
     echo $regularBar
-    npx markdown-link-check --config .mdlinkcheck-config.json -q -p ${mdFileList[*]} "$@"
+    npx markdown-link-check --config .mdlinkcheck-config.json -q -p $mdFileList "$@"
     linksPassed=$?
 
     echo " "
     echo $regularBar
     echo "${bold}Formatting check${normal}"
     echo $regularBar
-    npx markdownlint-cli2 ${mdFileList[*]} "$@"
+    npx markdownlint-cli2 $mdFileList "$@"
     formatPassed=$?
 
     errorDescr=""


### PR DESCRIPTION
This PR troubleshoots the "Bad substitution" error that pre-commit.sh sometimes throws. 

Basically, it looks like I was trying to expand an array, which is not necessary, because the input files list is a list of strings, not an array. 