### PR TITLE
Fix the command to start light node on Calibration

### DIFF
--- a/content/en/networks/calibration/rpcs/index.md
+++ b/content/en/networks/calibration/rpcs/index.md
@@ -30,7 +30,7 @@ Please note that publicly available hosted endpoints **only guarantee 2000 of th
 - Lotus lite-node command
 
   ```shell
-  FULLNODE_API_INFO=wss://wss.calibration.node.glif.io lotus daemon --lite
+  FULLNODE_API_INFO=wss://wss.calibration.node.glif.io/apigw/lotus lotus daemon --lite
   ```
 
   When using a lite-node, omit `/rpc/v1` from Glif's WebSocket address.


### PR DESCRIPTION
The Endpoint is not correct to use on Calibration for a light node. 

The current link will give an error 
```
API Token not set and requested, capabilities might be limited.
ERROR: cannot dial address wss://wss.calibration.node.glif.io/rpc/v1 for websocket: bad handshake: websocket: bad handshake
```