### PR TITLE
Removes lingering mentions of Hyperspace.

### DIFF
--- a/content/en/basics/assets/metamask-setup/index.md
+++ b/content/en/basics/assets/metamask-setup/index.md
@@ -1,7 +1,7 @@
 ---
 title: "MetaMask setup"
 description: "MetaMask is a popular browser extension that allows users to interact with blockchain applications. This guide shows you how to configure MetaMask to work with the Filecoin mainnet."
-lead: "MetaMask is a popular browser extension that allows users to interact with blockchain applications. This guide shows you how to configure MetaMask to work with the Filecoin mainnet, Calibration testnet, or the Hyperspace testnet."
+lead: "MetaMask is a popular browser extension that allows users to interact with blockchain applications. This guide shows you how to configure MetaMask to work with the Filecoin mainnet, Calibration testnet, or a local testnet."
 draft: false
 images: []
 type: docs
@@ -23,7 +23,7 @@ aliases:
 
 Chainlist is a website that lets users easily connect their wallets to EVM-compatible blockchains. Chainlist is managed by [DeFi Llama](https://defillama.com/). Chainlist is the simplest way to add the Filecoin network to your MetaMask wallet.
 
-{{< tabs tabTotal="4" >}}
+{{< tabs tabTotal="3" >}}
 {{< tab tabName="Mainnet" >}}
 <br>
 
@@ -47,19 +47,6 @@ Chainlist is a website that lets users easily connect their wallets to EVM-compa
 1. You may be shown a warning that you are connecting to a test network. If prompted, click **Accept**.
 1. Click **Switch network** when prompted by MetaMask.
 1. Open MetaMask from the browser extensions tab. You should see _Filecoin Calibration_ listed at the top.
-{{< /tab >}}
-{{< tab tabName="Hyperspace" >}}
-<br>
-
-1. Go [chainlist.org](https://chainlist.org).
-
-1. Click the **Include Testnets** checkbox.
-1. Search for [`Filecoin Hyperspace`](https://chainlist.org/chain/3141).
-1. Click **Connect Wallet**.
-1. Click **Approve** when prompted to _Allow this site to add a network_.
-1. You may be shown a warning that you are connecting to a test network. If prompted, click **Accept**.
-1. Click **Switch network** when prompted by MetaMask.
-1. Open MetaMask from the browser extensions tab. You should see _Filecoin Hyperspace_ listed at the top.
 {{< /tab >}}
 {{< tab tabName="Local-testnet" >}}
 <br>
@@ -93,7 +80,7 @@ Before we get started, you'll need the following:
 
 The process for configuring MetaMask to use Filecoin is fairly simple, but has some very specific variables that you must copy exactly.
 
-{{< tabs tabTotal="4" >}}
+{{< tabs tabTotal="3" >}}
 {{< tab tabName="Mainnet" >}}
 <br>
 
@@ -140,28 +127,6 @@ The process for configuring MetaMask to use Filecoin is fairly simple, but has s
 1. Done!
 {{< /tab >}}
 
-{{< tab tabName="Hyperspace" >}}
-<br>
-
-1. Open your browser and open the MetaMask plugin. If you haven't opened the MetaMask plugin before, you'll be prompted to create a new wallet. Follow the prompts to create a wallet.
-1. Click the user circle and select **Settings**:
-1. Select **Networks**.
-1. Click **Add a network**.
-1. Scroll down and click **Add a network manually**.
-1. Enter the following information into the fields:
-
-    | Field | Value |
-    | --- | --- |
-    | Network name | `Filecoin Hyperspace testnet` |
-    | New RPC URL | Either:<br> - `https://api.calibration.node.glif.io/rpc/v1` <br> - `https://filecoin-calibration.chainup.net/rpc/v1` <br> - `https://filecoin-calibration.chainstacklabs.com/rpc/v1` <br> - `https://rpc.ankr.com/filecoin_testnet` |
-    | Chain ID | `3141` |
-    | Currency symbol | `tFIL` |
-
-1. Pick one a [block explorers]({{< relref "/networks/calibration/explorers" >}}), and enter the URL into the **Block explorer (optional)** field.
-1. Review the values in the fields and click **Save**.
-1. The Filecoin network should now be shown in your MetaMask window.
-1. Done!
-{{< /tab >}}
 {{< tab tabName="Local-testnet" >}}
 <br>
 

--- a/content/en/smart-contracts/developing-contracts/foundry/index.md
+++ b/content/en/smart-contracts/developing-contracts/foundry/index.md
@@ -40,11 +40,11 @@ You should also have an address on the Filecoin Calibration testnet. See the [Ad
     ```
 
 1. Export your private key from MetaMask. See the [MetaMask documentation](https://support.metamask.io/hc/en-us/articles/360015289632-How-to-export-an-account-s-private-key) to find out how to export your private key.
-1. In your `.env.example`, create an environment variable called `PRIVATE_KEY` and paste in the private key from MetaMask. Also, do the same for the `HYPERSPACE_RPC_URL`. Then rename the file to `.env`:
+1. In your `.env.example`, create an environment variable called `PRIVATE_KEY` and paste in the private key from MetaMask. Also, do the same for the `CALIBRATION_RPC_URL`. Then rename the file to `.env`:
 
     ```markdown
     PRIVATE_KEY=eed8e9d727a647f7302bab440d405ea87d36726e7d9f233ab3ff88036cfbce9c
-    HYPERSPACE_RPC_URL=https://api.calibration.node.glif.io/rpc/v1
+    CALIBRATION_RPC_URL=https://api.calibration.node.glif.io/rpc/v1
     ```
 
 1. Inside the `src` folder in a contract called `SimpleCoin.sol`. Deploy this contract using Foundry:

--- a/content/en/smart-contracts/developing-contracts/remix/index.md
+++ b/content/en/smart-contracts/developing-contracts/remix/index.md
@@ -20,7 +20,7 @@ aliases:
 As a simple introduction, we're going to use Remix to create an ERC-20 token on the Filecoin network. In this guide, we're using the Calibration testnet, but this process is the same for mainnet.
 
 {{< alert >}}
-This guide assumes you've already connected your MetaMask extension to a Filecoin network. If you haven't done so yet, [check out this guide to add the Hyperspace testnet to MetaMask]({{< relref "/basics/assets/metamask-setup" >}}).
+This guide assumes you've already connected your MetaMask extension to a Filecoin network. If you haven't done so yet, [check out this guide to add the Calibration testnet to MetaMask]({{< relref "/basics/assets/metamask-setup" >}}).
 {{< /alert >}}
 
 ### Create a workspace
@@ -72,7 +72,7 @@ That's all we need to change within this contract. You can see on line 4 that th
 Now that we've successfully compiled our contract, we need to deploy it somewhere! This is where our previous MetaMask setup comes into play.
 
 {{< alert >}}
-This guide assumes you've already connected your MetaMask extension to a Filecoin network. If you haven't done so yet, [check out this guide to add the Hyperspace testnet to MetaMask]({{< relref "/basics/assets/metamask-setup" >}}).
+This guide assumes you've already connected your MetaMask extension to a Filecoin network. If you haven't done so yet, [check out this guide to add the Calibration testnet to MetaMask]({{< relref "/basics/assets/metamask-setup" >}}).
 {{< /alert >}}
 
 1. Click the **Deploy** tab from the left.

--- a/content/en/smart-contracts/fundamentals/FAQs/index.md
+++ b/content/en/smart-contracts/fundamentals/FAQs/index.md
@@ -80,9 +80,6 @@ Yes.
 
 Not necessarily. You can use any of the public RPC nodes on either [mainnet]({{< relref "/networks/mainnet/details" >}}) or the [Calibration testnet]({{< relref "/networks/calibration/details" >}}
 
-- `api.hyperspace.node.glif.io/rpc/v1`
-- `api.zondax.ch/fil/node/hyperspace/rpc/v1`
-
 #### What is the difference between the FVM and Bacalhau
 
 They are synergistic. Compute over data solutions such as [Bacalhau](https://github.com/filecoin-project/bacalhau) can use the FVM.


### PR DESCRIPTION
There were a few pages where we still had mentions of the Hyperspace testnet. It's been deprecated for a few weeks now. This PR removes those mentions of Hyperspace.