### PR TITLE
Link check: allow 400 and 403

### DIFF
--- a/.mdlinkcheck-config.json
+++ b/.mdlinkcheck-config.json
@@ -21,5 +21,5 @@
             }
         }
     ],
-    "aliveStatusCodes": [200, 206, 429]
+    "aliveStatusCodes": [200, 206, 400, 403, 429]
 }


### PR DESCRIPTION
Allows the pre commit link check to ignore 400 and 403 errors