### PR TITLE
Fixes table no-wrap on long strings.

### DIFF
--- a/assets/scss/common/_global.scss
+++ b/assets/scss/common/_global.scss
@@ -292,3 +292,11 @@ body {
 .d-xl-padding {
   padding-bottom: 15px;
 }
+
+table td:first-child, table th:first-child {
+    min-width: 20%;
+}
+
+td {
+    word-break: break-word;
+}


### PR DESCRIPTION
Closes https://github.com/filecoin-project/filecoin-docs/issues/1611

Also sets the first column of all tables to have a min-width of 20%.

![Untitled](https://github.com/filecoin-project/filecoin-docs/assets/9611008/93008b70-908e-4d42-adaa-7eabe3a456e6)
