### PR TITLE
Replace chainlist.org links

### DIFF
--- a/content/en/basics/assets/metamask-setup/index.md
+++ b/content/en/basics/assets/metamask-setup/index.md
@@ -27,39 +27,36 @@ Chainlist is a website that lets users easily connect their wallets to EVM-compa
 {{< tab tabName="Mainnet" >}}
 <br>
 
-1. Search for [`Filecoin`](https://chainlist.org/chain/314) on [chainlist.org](https://chainlist.org).
-
+1. Navigate to [chainlist.network](https://chainlist.network).
+1. Search for `Filecoin - Mainnet`.
 1. Click **Connect Wallet**.
 1. Click **Approve** when prompted to _Allow this site to add a network_.
 1. Click **Switch network** when prompted by MetaMask.
 1. Open MetaMask from the browser extensions tab.
 1. You should see _Filecoin_ listed at the top.
+
 {{< /tab >}}
 {{< tab tabName="Calibration" >}}
 <br>
 
-1. Go [chainlist.org](https://chainlist.org).
-
-1. Click the **Include Testnets** checkbox.
-1. Search for [`Filecoin Calibration`](https://chainlist.org/chain/314159).
+1. Navigate to [chainlist.network](https://chainlist.network).
+1. Search for `Filecoin - Calibration`.
 1. Click **Connect Wallet**.
 1. Click **Approve** when prompted to _Allow this site to add a network_.
 1. You may be shown a warning that you are connecting to a test network. If prompted, click **Accept**.
 1. Click **Switch network** when prompted by MetaMask.
-1. Open MetaMask from the browser extensions tab. You should see _Filecoin Calibration_ listed at the top.
+1. Open MetaMask from the browser extensions tab. You should see _Filecoin - Calibration_ listed at the top.
 {{< /tab >}}
 {{< tab tabName="Local-testnet" >}}
 <br>
 
-1. Go [chainlist.org](https://chainlist.org).
-
-1. Click the **Include Testnets** checkbox.
-1. Search for [`Filecoin Local testnet`](https://chainlist.org/chain/31415926).
+1. Navigate to [chainlist.network](https://chainlist.network).
+1. Search for `Filecoin - Local testnet`.
 1. Click **Connect Wallet**.
 1. Click **Approve** when prompted to _Allow this site to add a network_.
 1. You may be shown a warning that you are connecting to a test network. If prompted, click **Accept**.
 1. Click **Switch network** when prompted by MetaMask.
-1. Open MetaMask from the browser extensions tab. You should see _Filecoin Local testnet_ listed at the top.
+1. Open MetaMask from the browser extensions tab. You should see _Filecoin - Local testnet_ listed at the top.
 {{< /tab >}}
 {{< /tabs >}}
 

--- a/content/en/smart-contracts/fundamentals/erc-20-quickstart/index.md
+++ b/content/en/smart-contracts/fundamentals/erc-20-quickstart/index.md
@@ -53,18 +53,18 @@ Before we can interact with the Filecoin network, we need funds. But before we c
 
 ### Switch networks
 
-You may notice that we are currently connected to the **Ethereum Mainnet**. We need to point MetaMask to the Filecoin network, specifically the [Calibration testnet]({{< relref "/networks/calibration/details" >}}). We'll use a website called [chainlist.org](https://chainlist.org/) to give MetaMask the information it needs quickly.
+You may notice that we are currently connected to the **Ethereum Mainnet**. We need to point MetaMask to the Filecoin network, specifically the [Calibration testnet]({{< relref "/networks/calibration/details" >}}). We'll use a website called [chainlist.network](https://chainlist.network/) to give MetaMask the information it needs quickly.
 
-1. Go to [chainlist.org](https://chainlist.org/).
-1. Enable the **Testnets** toggle and enter `Filecoin` into the search bar.
+1. Go to [chainlist.network](https://chainlist.network/).
+1. Enter `Filecoin` into the search bar.
 
     ![Search for Filecoin testnets in Chainlist.](chainlist-search-for-filecoin-testnets.png)
 
-1. Scroll down to find the **Filecoin -- Calibration** testnet:
+1. Scroll down to find the **Filecoin - Calibration** testnet:
 
     ![Find the Calibration testnet.](chainlist-select-calibration.png)
 
-1. In MetaMask click **Next**.
+1. In MetaMask, click **Next**.
 
     ![Click next in MetaMask.](chainlist-connect-with-metamask.png)
 


### PR DESCRIPTION
Addresses https://github.com/filecoin-project/filecoin-docs/issues/2052

Note that the tabbed set of instructions for using chainlist in `metamask-setup` were slightly adjusted as well, as the add wallet flow on chainlist.network is different than the chainlist.org flow