### PR TITLE
Adds scrolls-progress-bar.

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -1,179 +1,179 @@
-var suggestions = document.getElementById('suggestions');
-var search = document.getElementById('search');
+// var suggestions = document.getElementById('suggestions');
+// var search = document.getElementById('search');
 
-if (search !== null) {
-  document.addEventListener('keydown', inputFocus);
-}
+// if (search !== null) {
+//   document.addEventListener('keydown', inputFocus);
+// }
 
-function inputFocus(e) {
-  if (e.ctrlKey && e.key === '/' ) {
-    e.preventDefault();
-    search.focus();
-  }
-  if (e.key === 'Escape' ) {
-    search.blur();
-    suggestions.classList.add('d-none');
-  }
-}
+// function inputFocus(e) {
+//   if (e.ctrlKey && e.key === '/' ) {
+//     e.preventDefault();
+//     search.focus();
+//   }
+//   if (e.key === 'Escape' ) {
+//     search.blur();
+//     suggestions.classList.add('d-none');
+//   }
+// }
 
-document.addEventListener('click', function(event) {
+// document.addEventListener('click', function(event) {
 
-  var isClickInsideElement = suggestions.contains(event.target);
+//   var isClickInsideElement = suggestions.contains(event.target);
 
-  if (!isClickInsideElement) {
-    suggestions.classList.add('d-none');
-  }
+//   if (!isClickInsideElement) {
+//     suggestions.classList.add('d-none');
+//   }
 
-});
+// });
 
-/*
-Source:
-  - https://dev.to/shubhamprakash/trap-focus-using-javascript-6a3
-*/
+// /*
+// Source:
+//   - https://dev.to/shubhamprakash/trap-focus-using-javascript-6a3
+// */
 
-document.addEventListener('keydown',suggestionFocus);
+// document.addEventListener('keydown',suggestionFocus);
 
-function suggestionFocus(e) {
-  const suggestionsHidden = suggestions.classList.contains('d-none');
-  if (suggestionsHidden) return;
+// function suggestionFocus(e) {
+//   const suggestionsHidden = suggestions.classList.contains('d-none');
+//   if (suggestionsHidden) return;
 
-  const focusableSuggestions= [...suggestions.querySelectorAll('a')];
-  if (focusableSuggestions.length === 0) return;
+//   const focusableSuggestions= [...suggestions.querySelectorAll('a')];
+//   if (focusableSuggestions.length === 0) return;
 
-  const index = focusableSuggestions.indexOf(document.activeElement);
+//   const index = focusableSuggestions.indexOf(document.activeElement);
 
-  if (e.key === "ArrowUp") {
-    e.preventDefault();
-    const nextIndex = index > 0 ? index - 1 : 0;
-    focusableSuggestions[nextIndex].focus();
-  }
-  else if (e.key === "ArrowDown") {
-    e.preventDefault();
-    const nextIndex= index + 1 < focusableSuggestions.length ? index + 1 : index;
-    focusableSuggestions[nextIndex].focus();
-  }
+//   if (e.key === "ArrowUp") {
+//     e.preventDefault();
+//     const nextIndex = index > 0 ? index - 1 : 0;
+//     focusableSuggestions[nextIndex].focus();
+//   }
+//   else if (e.key === "ArrowDown") {
+//     e.preventDefault();
+//     const nextIndex= index + 1 < focusableSuggestions.length ? index + 1 : index;
+//     focusableSuggestions[nextIndex].focus();
+//   }
 
-}
+// }
 
-/*
-Source:
-  - https://github.com/nextapps-de/flexsearch#index-documents-field-search
-  - https://raw.githack.com/nextapps-de/flexsearch/master/demo/autocomplete.html
-*/
+// /*
+// Source:
+//   - https://github.com/nextapps-de/flexsearch#index-documents-field-search
+//   - https://raw.githack.com/nextapps-de/flexsearch/master/demo/autocomplete.html
+// */
 
-(function(){
+// (function(){
 
-  var index = new FlexSearch.Document({
-    tokenize: "forward",
-    cache: 100,
-    document: {
-      id: 'id',
-      store: [
-        "href", "title", "description"
-      ],
-      index: ["title", "description", "content"]
-    }
-  });
+//   var index = new FlexSearch.Document({
+//     tokenize: "forward",
+//     cache: 100,
+//     document: {
+//       id: 'id',
+//       store: [
+//         "href", "title", "description"
+//       ],
+//       index: ["title", "description", "content"]
+//     }
+//   });
 
 
-  // Not yet supported: https://github.com/nextapps-de/flexsearch#complex-documents
+//   // Not yet supported: https://github.com/nextapps-de/flexsearch#complex-documents
 
-  /*
-  var docs = [
-    {{ range $index, $page := (where .Site.Pages "Section" "docs") -}}
-      {
-        id: {{ $index }},
-        href: "{{ .Permalink }}",
-        title: {{ .Title | jsonify }},
-        description: {{ .Params.description | jsonify }},
-        content: {{ .Content | jsonify }}
-      },
-    {{ end -}}
-  ];
-  */
+//   /*
+//   var docs = [
+//     {{ range $index, $page := (where .Site.Pages "Section" "docs") -}}
+//       {
+//         id: {{ $index }},
+//         href: "{{ .Permalink }}",
+//         title: {{ .Title | jsonify }},
+//         description: {{ .Params.description | jsonify }},
+//         content: {{ .Content | jsonify }}
+//       },
+//     {{ end -}}
+//   ];
+//   */
 
-  // https://discourse.gohugo.io/t/range-length-or-last-element/3803/2
+//   // https://discourse.gohugo.io/t/range-length-or-last-element/3803/2
 
-  {{ $list := slice }}
-  {{- if and (isset .Site.Params.options "searchsectionsindex") (not (eq (len .Site.Params.options.searchSectionsIndex) 0)) }}
-  {{- if eq .Site.Params.options.searchSectionsIndex "ALL" }}
-  {{- $list = .Site.Pages }}
-  {{- else }}
-  {{- $list = (where .Site.Pages "Type" "in" .Site.Params.options.searchSectionsIndex) }}
-  {{- if (in .Site.Params.options.searchSectionsIndex "HomePage") }}
-  {{ $list = $list | append .Site.Home }}
-  {{- end }}
-  {{- end }}
-  {{- else }}
-  {{- $list = (where .Site.Pages "Section" "docs") }}
-  {{- end }}
+//   {{ $list := slice }}
+//   {{- if and (isset .Site.Params.options "searchsectionsindex") (not (eq (len .Site.Params.options.searchSectionsIndex) 0)) }}
+//   {{- if eq .Site.Params.options.searchSectionsIndex "ALL" }}
+//   {{- $list = .Site.Pages }}
+//   {{- else }}
+//   {{- $list = (where .Site.Pages "Type" "in" .Site.Params.options.searchSectionsIndex) }}
+//   {{- if (in .Site.Params.options.searchSectionsIndex "HomePage") }}
+//   {{ $list = $list | append .Site.Home }}
+//   {{- end }}
+//   {{- end }}
+//   {{- else }}
+//   {{- $list = (where .Site.Pages "Section" "docs") }}
+//   {{- end }}
 
-  {{ $len := (len $list) -}}
+//   {{ $len := (len $list) -}}
 
-  {{ range $index, $element := $list -}}
-    index.add(
-      {
-        id: {{ $index }},
-        href: "{{ .RelPermalink }}",
-        title: {{ .Title | jsonify }},
-        {{ with .Description -}}
-          description: {{ . | jsonify }},
-        {{ else -}}
-          description: {{ .Summary | plainify | jsonify }},
-        {{ end -}}
-        content: {{ .Plain | jsonify }}
-      }
-    );
-  {{ end -}}
+//   {{ range $index, $element := $list -}}
+//     index.add(
+//       {
+//         id: {{ $index }},
+//         href: "{{ .RelPermalink }}",
+//         title: {{ .Title | jsonify }},
+//         {{ with .Description -}}
+//           description: {{ . | jsonify }},
+//         {{ else -}}
+//           description: {{ .Summary | plainify | jsonify }},
+//         {{ end -}}
+//         content: {{ .Plain | jsonify }}
+//       }
+//     );
+//   {{ end -}}
 
-  search.addEventListener('input', show_results, true);
+//   search.addEventListener('input', show_results, true);
 
-  function show_results(){
-    const maxResult = 5;
-    var searchQuery = this.value;
-    var results = index.search(searchQuery, {limit: maxResult, enrich: true});
+//   function show_results(){
+//     const maxResult = 5;
+//     var searchQuery = this.value;
+//     var results = index.search(searchQuery, {limit: maxResult, enrich: true});
 
-    // flatten results since index.search() returns results for each indexed field
-    const flatResults = new Map(); // keyed by href to dedupe results
-    for (const result of results.flatMap(r => r.result)) {
-      if (flatResults.has(result.doc.href)) continue;
-      flatResults.set(result.doc.href, result.doc);
-    }
+//     // flatten results since index.search() returns results for each indexed field
+//     const flatResults = new Map(); // keyed by href to dedupe results
+//     for (const result of results.flatMap(r => r.result)) {
+//       if (flatResults.has(result.doc.href)) continue;
+//       flatResults.set(result.doc.href, result.doc);
+//     }
 
-    suggestions.innerHTML = "";
-    suggestions.classList.remove('d-none');
+//     suggestions.innerHTML = "";
+//     suggestions.classList.remove('d-none');
 
-    // inform user that no results were found
-    if (flatResults.size === 0 && searchQuery) {
-      const noResultsMessage = document.createElement('div')
-      noResultsMessage.innerHTML = `No results for "<strong>${searchQuery}</strong>"`
-      noResultsMessage.classList.add("suggestion__no-results");
-      suggestions.appendChild(noResultsMessage);
-      return;
-    }
+//     // inform user that no results were found
+//     if (flatResults.size === 0 && searchQuery) {
+//       const noResultsMessage = document.createElement('div')
+//       noResultsMessage.innerHTML = `No results for "<strong>${searchQuery}</strong>"`
+//       noResultsMessage.classList.add("suggestion__no-results");
+//       suggestions.appendChild(noResultsMessage);
+//       return;
+//     }
 
-    // construct a list of suggestions
-    for(const [href, doc] of flatResults) {
-        const entry = document.createElement('div');
-        suggestions.appendChild(entry);
+//     // construct a list of suggestions
+//     for(const [href, doc] of flatResults) {
+//         const entry = document.createElement('div');
+//         suggestions.appendChild(entry);
 
-        const a = document.createElement('a');
-        a.href = href;
-        entry.appendChild(a);
+//         const a = document.createElement('a');
+//         a.href = href;
+//         entry.appendChild(a);
 
-        const title = document.createElement('span');
-        title.textContent = doc.title;
-        title.classList.add("suggestion__title");
-        a.appendChild(title);
+//         const title = document.createElement('span');
+//         title.textContent = doc.title;
+//         title.classList.add("suggestion__title");
+//         a.appendChild(title);
 
-        const description = document.createElement('span');
-        description.textContent = doc.description;
-        description.classList.add("suggestion__description");
-        a.appendChild(description);
+//         const description = document.createElement('span');
+//         description.textContent = doc.description;
+//         description.classList.add("suggestion__description");
+//         a.appendChild(description);
 
-        suggestions.appendChild(entry);
+//         suggestions.appendChild(entry);
 
-        if(suggestions.childElementCount == maxResult) break;
-    }
-  }
-}());
+//         if(suggestions.childElementCount == maxResult) break;
+//     }
+//   }
+// }());

--- a/assets/js/progressbar.js
+++ b/assets/js/progressbar.js
@@ -1,0 +1,9 @@
+// When the user scrolls the page, execute myFunction
+window.onscroll = function() {move_progressbar()};
+
+function move_progressbar() {
+  var winScroll = document.body.scrollTop || document.documentElement.scrollTop;
+  var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
+  var scrolled = (winScroll / height) * 100;
+  document.getElementById("progress_bar").style.width = scrolled + "%";
+}

--- a/assets/scss/layouts/_header.scss
+++ b/assets/scss/layouts/_header.scss
@@ -138,14 +138,25 @@ button#doks-versions {
 }
 */
 
+/* Progress bar */
 .header-bar {
-  border-top: 4px solid;
-  border-image-source: linear-gradient(90deg, $primary, $blue-400 50%, #d32e9d);
-  border-image-slice: 1;
+    height: 4px;
 }
 
-.offcanvas .header-bar {
-  margin-bottom: -4px;
+/* The progress container */
+.progress-container {
+    // margin-top: 8px;
+    width: 100%;
+    height: 4px;
+    background: white;
+}
+
+/* The progress bar scroll indicator */
+.progress-bar {
+  height: 4px;
+  border-top: 4px solid;
+  border-image-source: linear-gradient(90deg, $primary, #d32e9d);
+  border-image-slice: 1;
 }
 
 .home .navbar {

--- a/layouts/partials/footer/script-footer.html
+++ b/layouts/partials/footer/script-footer.html
@@ -62,6 +62,12 @@
   {{ $slice = $slice | append $katexConfig -}}
 {{ end -}}
 
+{{ if .Site.Params.options.progressBar -}}
+  {{ $progressbarConfig := resources.Get "js/progressbar.js" -}}
+  {{ $progressbarConfig := $progressbarConfig | js.Build -}}
+  {{ $slice = $slice | append $progressbarConfig -}}
+{{ end -}}
+
 {{ $scrollLock := resources.Get "js/scroll-lock.js" | js.Build -}}
 {{ $slice = $slice | append $scrollLock -}}
 

--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -6,7 +6,9 @@
 <div class="sticky-top">
 {{ end -}}
 
-<div class="header-bar"></div>
+<div class="progress-container">
+    <div class="progress-bar header-bar" id="progress_bar"></div>
+</div>
 
 <header class="navbar navbar-expand-lg navbar-light doks-navbar">
   <nav class="container-{{ if .Site.Params.options.fullWidth }}fluid{{ else }}xxl{{ end }} flex-wrap flex-lg-nowrap" aria-label="Main navigation">


### PR DESCRIPTION
Turns the top bar gradient into a fun little scrolls progress bar thing. The progress bar can be disabled by changing `progressBar` to `false` in `/config/_default/params.toml`.

![ezgif-2-2e126b2e08](https://github.com/filecoin-project/filecoin-docs/assets/9611008/511e637c-4275-492b-811e-752a6fab77ca)

This PR also disables the old search `index.js` file so we shouldn't get any more _Can't find `search`_ errors in the console anymore.
