### PR TITLE
Fixes YAML file.

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -4,6 +4,5 @@ structure:
     readme: README.md  
     summary: SUMMARY.md
 
-# redirects:  
-#     previous/page: new-folder/page.md
+redirects:  
       basics/what-is-filecoin/overview: basics/readme.md


### PR DESCRIPTION
The `redirects:` line was commented out, leading to an error in the GitBook frontend. This PR uncomments that line.