### PR TITLE
Update the-fil-token.md

### DIFF
--- a/basics/assets/the-fil-token.md
+++ b/basics/assets/the-fil-token.md
@@ -22,10 +22,6 @@ When a user wants to retrieve their data from the Filecoin network, they make a 
 
 FIL is used to reward providers who validate and add new blocks to the Filecoin blockchain. Providers receive a block reward in FIL for each new block they add to the blockchain and also earn transaction fees in FIL for processing storage and retrieval transactions.
 
-### Governance
-
-FIL is used for network governance, allowing FIL holders to vote on proposals and make decisions that impact the future development and direction of the network.
-
 ## Denominations
 
 FIL, NanoFIL, and PicoFIL are all denominated in the same cryptocurrency unit, but they represent different levels of precision and granularity. For most users, FIL is the main unit of measurement and is used for most transactions and payments on the Filecoin network.


### PR DESCRIPTION
The section on governance needs to be removed; it is incorrect.  Though we have tried experiments in the past with the FIL token, it is not required for participating in governance, nor do we use it for voting on proposals.