### PR TITLE
Create check-external-links.yml

### DIFF
--- a/.github/workflows/check-external-links.yml
+++ b/.github/workflows/check-external-links.yml
@@ -1,0 +1,18 @@
+name: Check external links
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  linkChecker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v1.8.0
+        with:
+          args: --accept 200,429,403 '**/*.md'
+          fail: true

--- a/.github/workflows/check-external-links.yml
+++ b/.github/workflows/check-external-links.yml
@@ -2,7 +2,7 @@ name: Check external links
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ production ]
 
 jobs:
   linkChecker:


### PR DESCRIPTION
Check all markdown files for external links. 404 return errors and will halt a PR. 200, 403, and 429 HTTP errors will _not_ halt a PR.