### PR TITLE
Changes 503ing links to codeblocks for now.

### DIFF
--- a/basics/interplanetary-consensus/ipc-agent.md
+++ b/basics/interplanetary-consensus/ipc-agent.md
@@ -169,7 +169,7 @@ To check if the agent has been connected to Spacenet successfully you can try cr
 2023-03-30T12:01:11Z INFO  ipc_agent::cli::commands::manager::wallet] created new wallet with address WalletNewResponse { address: "t1om5pijjq5dqic4ccnqqrvv6zgzwrlxf6bh2apvi" } in subnet "/root"
 ```
 
-Finally, to be able to interact with Spacenet and run new subnets, some FIL should be provided to, at least, the wallet that will be used by the agent to interact with IPC. You can request some Spacenet FIL for your address through the [Spacenet Faucet](https://spacenet.consensus.ninja/).
+Finally, to be able to interact with Spacenet and run new subnets, some FIL should be provided to, at least, the wallet that will be used by the agent to interact with IPC. You can request some Spacenet FIL for your address through the `spacenet.consensus.ninja`.
 
 #### Local deployment
 

--- a/networks/spacenet/get-test-tokens.md
+++ b/networks/spacenet/get-test-tokens.md
@@ -7,7 +7,7 @@ description: >-
 
 # Get test tokens
 
-A faucet is available at [faucet.spacenet.ipc.space](https://faucet.spacenet.ipc.space) for developers to get test Filecoin (tFIL) on the Spacenet testnet. The faucet has the following restrictions:
+A faucet is available at `faucet.spacenet.ipc.space` for developers to get test Filecoin (tFIL) on the Spacenet testnet. The faucet has the following restrictions:
 
 * The per-request allowance given by the faucet is 10 tFIL.
 * There is a daily maximum of 20 tFIL per address.


### PR DESCRIPTION
A couple of links related to IPC are 503ing. This PR removes them for now. We should revert this PR once the links are back up.