### PR TITLE
Updated GO instructions

### DIFF
--- a/content/en/nodes/lite-nodes/spin-up-a-lite-node/index.md
+++ b/content/en/nodes/lite-nodes/spin-up-a-lite-node/index.md
@@ -59,7 +59,8 @@ To build the lite-node, you'll need some specific software. Run the following co
 1. Install Go and add `/usr/local/go/bin` to your `$PATH` variable:
 
     ```shell
-    wget -c https://golang.org/dl/go1.18.8.linux-amd64.tar.gz -O - | sudo tar -xz -C /usr/local
+    wget https://go.dev/dl/go1.21.1.linux-amd64.tar.gz
+    sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.21.1.linux-amd64.tar.gz   
     echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.bashrc && source ~/.bashrc
     ```
 


### PR DESCRIPTION
Updated GO download and install instructions to new URL, new version and following official steps stated [here](https://go.dev/doc/install).