### PR TITLE
Uses api.node.glif.io addresses.

### DIFF
--- a/networks/calibration/explorers.md
+++ b/networks/calibration/explorers.md
@@ -18,7 +18,7 @@ description: >-
 
 [calibration.filscan.io](https://calibration.filscan.io/)
 
-## Glif Explorer [#](https://docs.filecoin.io/networks/calibration/explorers/#glif-explorer) <a href="#glif-explorer" id="glif-explorer"></a>
+## Glif Explorer
 
 [explorer.glif.io](https://explorer.glif.io/?network=calibration)
 

--- a/networks/calibration/rpcs.md
+++ b/networks/calibration/rpcs.md
@@ -27,7 +27,7 @@ These endpoints are limited to [read-only Filecoin JSON RPC API calls](../../ref
 * WebSocket: `wss://ws-filecoin-calibration.chainstacklabs.com/rpc/v1`
 * [Chainstack documentation](https://chainstack.com/labs/#filecoin)
 
-## [Glif](https://glif.io)
+## [Glif](https://api.calibration.node.glif.io)
 
 Please note that publicly available hosted endpoints **only guarantee 2000 of the latest blocks.**
 

--- a/networks/mainnet/rpcs.md
+++ b/networks/mainnet/rpcs.md
@@ -25,7 +25,7 @@ description: Public RPC endpoints are available for the Filecoin mainnet.
 * WebSocket: `wss://filecoin.chainup.net/rpc/v1`
 * [ChainupCloud documentation](https://docs.chainupcloud.com/blockchain-api/filecoin/public-apis)
 
-## [Glif](https://glif.io)
+## [Glif](https://api.node.glif.io)
 
 Please note that publicly available hosted endpoints **only guarantee 2000 of the latest blocks.**
 


### PR DESCRIPTION
Closes https://github.com/filecoin-project/filecoin-docs/issues/2213