### PR TITLE
Filecoin blockchain archival data link(s)

### DIFF
--- a/networks/calibration/README.md
+++ b/networks/calibration/README.md
@@ -58,4 +58,5 @@ The following storage providers are running on the Calibration testnet.
 * [Stats Dashboard](https://stats.calibration.fildev.network/)
 * [Slack Channel for Updates: #fil-network-announcements](https://filecoinproject.slack.com/archives/C01AC6999KQ)
 * [Slack Channel for Questions: #fil-help](https://filecoinproject.slack.com/archives/CEGN061C5)
-* [Latest lightweight snapshot](https://forest.chainsafe.io/calibnet/snapshot-latest) generated with [Forest](http://github.com/ChainSafe/forest) by [ChainSafe](https://chainsafe.io/)
+* [Latest lightweight snapshot](https://forest-archive.chainsafe.dev/latest/calibnet/) generated with [Forest](http://github.com/ChainSafe/forest) by [ChainSafe](https://chainsafe.io/)
+* [Complete calibration net archival data](https://forest-archive.chainsafe.dev/list/) generated with [Forest](http://github.com/ChainSafe/forest) by [ChainSafe](https://chainsafe.io/)

--- a/networks/mainnet/README.md
+++ b/networks/mainnet/README.md
@@ -49,7 +49,8 @@ description: >-
 ## Resources
 
 * [Latest lightweight snapshot](https://snapshots.mainnet.filops.net/minimal/latest) generated with [Lotus](https://lotus.filecoin.io/) by [Protocol Labs](https://protocol.ai/)
-* [Latest lightweight snapshot](https://forest.chainsafe.io/mainnet/snapshot-latest) generated with [Forest](http://github.com/ChainSafe/forest) by [ChainSafe](https://chainsafe.io/)
+* [Latest lightweight snapshot](https://forest-archive.chainsafe.dev/latest/mainnet/) generated with [Forest](http://github.com/ChainSafe/forest) by [ChainSafe](https://chainsafe.io/)
+* [Complete Filecoin blockchain archival data](https://forest-archive.chainsafe.dev/list/) generated with [Forest](http://github.com/ChainSafe/forest) by [ChainSafe](https://chainsafe.io/)
 * [Status page and incidents](https://filecoin.statuspage.io/)
 * [Stats dashboard](https://stats.filecoin.io/)
 * [Slack Channel for Updates: #fil-network-announcements](https://filecoinproject.slack.com/archives/C01AC6999KQ)


### PR DESCRIPTION
- updated links for Forest generated latest snapshots
- new website link (hosted by the Forest team) for the entire Filecoin blockchain archival data [calibration net and main net]