### PR TITLE
Updating to Chainlist.org, now that deprecated testnets have been removed from their website

### DIFF
--- a/networks/calibration/README.md
+++ b/networks/calibration/README.md
@@ -4,7 +4,11 @@ description: >-
   Filecoin mainnet.
 ---
 
-# Calibration
+# Calibration testnet
+
+{% hint style="info" %}
+Also see [Calibration RPCs](./rpcs.md) and [Calibration Explorers](./explorers.md).
+{% endhint %}
 
 Prospective storage providers can experience more realistic sealing performance and hardware requirements using final proofs constructions and parameters. Storage clients can store and retrieve _real data_ on the network. Clients can also participate in deal-making workflows and storage and retrieval functionality. The sector size on the Calibration testnet is the same as on the Filecoin mainnet; 32 GiB and 64 GiB sectors are supported. This testnet also includes the Filecoin EVM-runtime features found on the Filecoin mainnet.
 

--- a/networks/calibration/rpcs.md
+++ b/networks/calibration/rpcs.md
@@ -4,11 +4,11 @@ description: Public RPC endpoints are available for the Calibration testnet.
 
 # RPCs
 
-These endpoints are limited to [read-only Filecoin JSON RPC API calls](../../reference/json-rpc/) and [`MPoolPush`](../../reference/json-rpc/mpool.md) for sending messages that have already been signed.
-
 {% hint style="info" %}
-[ChainID.network](https://chainid.network) contains a dynamically updated list of available RPCs along with stats like current block-height and latency. [Find out more at chainid.network](https://chainid.network). Select the filter icon and click **Show Testnets** to view available test networks.
+[Chainlist](https://chainlist.org/?search=filecoin&testnets=true) contains a dynamically updated list of available Filecoin RPCs. Select **Include Testnets** to view available test networks. [Find out more at chainlist.org's Filecoin listings](https://chainlist.org/?search=filecoin&testnets=true). 
 {% endhint %}
+
+These endpoints are limited to [read-only Filecoin JSON RPC API calls](../../reference/json-rpc/) and [`MPoolPush`](../../reference/json-rpc/mpool.md) for sending messages that have already been signed.
 
 ## [Ankr](https://www.ankr.com/rpc/filecoin)
 

--- a/networks/mainnet/README.md
+++ b/networks/mainnet/README.md
@@ -6,6 +6,10 @@ description: >-
 
 # Mainnet
 
+{% hint style="info" %}
+Also see [Mainnet RPCs](./rpcs.md) and [Mainnet Explorers](./explorers.md).
+{% endhint %}
+
 **Maintainer**: [Protocol Labs](https://protocol.ai)
 
 ## Genesis

--- a/networks/mainnet/rpcs.md
+++ b/networks/mainnet/rpcs.md
@@ -5,8 +5,10 @@ description: Public RPC endpoints are available for the Filecoin mainnet.
 # RPCs
 
 {% hint style="info" %}
-[ChainID.network](https://chainid.network) contains a dynamically updated list of available RPCs along with stats like current block-height and latency. [Find out more at chainid.network](https://chainid.network).
+[Chainlist](https://chainlist.org/?search=filecoin&testnets=true) contains a dynamically updated list of available Filecoin RPCs. [Find out more at chainlist.org's Filecoin listings](https://chainlist.org/?search=filecoin&testnets=true).
 {% endhint %}
+
+These endpoints are limited to [read-only Filecoin JSON RPC API calls](../../reference/json-rpc/) and [`MPoolPush`](../../reference/json-rpc/mpool.md) for sending messages that have already been signed.
 
 ## [Ankr](https://ankr.com)
 

--- a/reference/general/README.md
+++ b/reference/general/README.md
@@ -71,7 +71,6 @@ Tools to check status and details of the network and chain.
 Web-based applications that store your data on Filecoin. No command-line or coding experience required.
 
 * [Estuary](https://estuary.tech) allows uploading and storing content on the Filecoin network directly from your browser. Allows anyone with public data to store and retrieve using a few API calls.
-* [**Slate.host**](https://slate.host) - a storage application on Filecoin to collect, organize, and link files together and share them, listed on [Product Hunt here](https://www.producthunt.com/posts/slate-f195dcdd-18e2-4dc2-8c70-45208ccbb862) on GitHub at [`filecoin-project/slate`](https://github.com/filecoin-project/slate/)
 * [ChainSafe Files](https://files.chainsafe.io/) - Dropbox-style UI, login with OAuth or general MetaMask
 * [`File.video`](https://file.video/) - video hosting with decentralized transcoding from LivePeer
 * [Starling Framework for Data Integrity](https://www.starlinglab.org/)

--- a/storage-providers/filecoin-deals/filecoin-programs.md
+++ b/storage-providers/filecoin-deals/filecoin-programs.md
@@ -34,10 +34,6 @@ A overview of the Slingshot project from the Enterprise Storage Provider Acceler
 
 [Evergreen](https://evergreen.filecoin.io/) extends the Slingshot program by aiming to store the open datasets forever. Standard deals have a maximum duration of 540 days, which is not long enough for valuable, open datasets that might need to be stored forever. Evergreen uses a deal engine ([Spade](https://github.com/ribasushi/spade)) that automatically renews deals to extend the lifetime of the dataset on-chain.
 
-## Moon Landing
-
-[Moon Landing](https://moon-landing.io) is a program related to Slingshot and Evergreen. Moon Landing aims to provide assistance for new storage providers to enter the Slingshot program. They provide technical assistance as well as establishing contacts with other storage providers. Participants in the Moon Landing program are matched with other storage providers in a capsule. The intent is to grow communities of storage providers that can learn from each other and can share data replicas with each other.
-
 ## Saturn
 
 A whole new access capability is being launched with [Saturn](https://saturn.tech), which is the world’s first Web3 Content Delivery Network (CDN). Saturn, as a fully distributed CDN, allows clients to access their data via Saturn nodes close to them. Content retrieval times of less than 1 second will open up various new use-cases for Filecoin and create a new market for retrieval providers (L1 Saturn nodes) in which storage providers can also participate.


### PR DESCRIPTION
- Also adding quick links to the top of each network page to RPCs and Explorers