### PR TITLE
chore: Remove dead snapshot links

### DIFF
--- a/networks/calibration/README.md
+++ b/networks/calibration/README.md
@@ -45,7 +45,7 @@ Developers can reference pre-existing deals that are already available on the ne
 
 ## Snapshots <a href="#snapshots" id="snapshots"></a>
 
-* [Latest minimal snapshot](https://snapshots.calibrationnet.filops.net/minimal/latest.zst)
+* [Latest minimal snapshot](https://forest-archive.chainsafe.dev/latest/calibnet/)
 
 ## Active storage providers <a href="#active-storage-providers" id="active-storage-providers"></a>
 

--- a/networks/mainnet/README.md
+++ b/networks/mainnet/README.md
@@ -52,7 +52,6 @@ Also see [Mainnet RPCs](./rpcs.md) and [Mainnet Explorers](./explorers.md).
 
 ## Resources
 
-* [Latest lightweight snapshot](https://snapshots.mainnet.filops.net/minimal/latest) generated with [Lotus](https://lotus.filecoin.io/) by [Protocol Labs](https://protocol.ai/)
 * [Latest lightweight snapshot](https://forest-archive.chainsafe.dev/latest/mainnet/) generated with [Forest](http://github.com/ChainSafe/forest) by [ChainSafe](https://chainsafe.io/)
 * [Complete Filecoin blockchain archival data](https://forest-archive.chainsafe.dev/list/) generated with [Forest](http://github.com/ChainSafe/forest) by [ChainSafe](https://chainsafe.io/)
 * [Status page and incidents](https://filecoin.statuspage.io/)

--- a/storage-providers/architecture/lotus-components.md
+++ b/storage-providers/architecture/lotus-components.md
@@ -33,7 +33,7 @@ The machine running the Lotus daemon must be connected to the public internet fo
 
 Syncing the chain is a key role of the daemon. It communicates with the other nodes on the network by sending messages, which are, in turn, collected into [blocks](https://docs.filecoin.io/reference/general/glossary/#block). These blocks are then collected into [tipsets](https://docs.filecoin.io/reference/general/glossary/#tipset). Your Lotus daemon receives the messages on-chain, enabling you to maintain consensus about the state of the Filecoin network with all the other participants.
 
-Due to the growth in the size of the chain since its genesis, it is not advised for storage providers to sync the entire history of the network. Instead, providers should use the available [lightweight snapshots](https://lotus.filecoin.io/kb/chain-snapshots/) to import the most recent messages. One exception in which a provider would need to sync the entire chain would be to run a blockchain explorer.
+Due to the growth in the size of the chain since its genesis, it is not advised for storage providers to sync the entire history of the network. Instead, providers should use the available [lightweight snapshots](https://lotus.filecoin.io/lotus/manage/chain-management/#lightweight-snapshot) to import the most recent messages. One exception in which a provider would need to sync the entire chain would be to run a blockchain explorer.
 
 Synced chain data should be stored on an SSD; however, faster NVMe drives are strongly recommended. A slow chain sync can lead to delays in critical messages being sent on-chain from your Lotus miner, resulting in the faulting of sectors and the slashing of collateral.
 


### PR DESCRIPTION
The FilOps Snapshots has been retired/replaced by the Forest snapshots. Update a link to the correct Lotus snapshot page.