### PR TITLE
Update Calibnet-faucet links

### DIFF
--- a/basics/what-is-filecoin/networks.md
+++ b/basics/what-is-filecoin/networks.md
@@ -20,5 +20,5 @@ Test networks, or testnets, are version of the Filecoin network that attempt to 
 
 * [Public endpoint](https://api.calibration.node.glif.io/rpc/v0)
 * [Blockchain explorer](https://calibration.filscan.io/)
-* [Calibration Faucet - Zondax](https://faucet.calibnet.chainsafe-fil.io)
+* [Calibration Faucet - Chainsafe](https://faucet.calibnet.chainsafe-fil.io)
 * [Calibration Faucet - Zondax](https://beryx.zondax.ch/faucet/)

--- a/basics/what-is-filecoin/networks.md
+++ b/basics/what-is-filecoin/networks.md
@@ -20,4 +20,5 @@ Test networks, or testnets, are version of the Filecoin network that attempt to 
 
 * [Public endpoint](https://api.calibration.node.glif.io/rpc/v0)
 * [Blockchain explorer](https://calibration.filscan.io/)
-* [Faucet](https://faucet.calibration.fildev.network/)
+* [Calibration Faucet - Zondax](https://faucet.calibnet.chainsafe-fil.io)
+* [Calibration Faucet - Zondax](https://beryx.zondax.ch/faucet/)

--- a/networks/calibration/README.md
+++ b/networks/calibration/README.md
@@ -57,8 +57,9 @@ The following storage providers are running on the Calibration testnet.
 
 ## Resources <a href="#resources" id="resources"></a>
 
-* [Faucet](https://faucet.calibration.fildev.network/)
-* [DataCap allocation](https://faucet.calibration.fildev.network/)
+* [Calibration Faucet - Zondax](https://faucet.calibnet.chainsafe-fil.io)
+* [Calibration Faucet - Zondax](https://beryx.zondax.ch/faucet/)
+* [DataCap allocation](https://faucet.calibnet.chainsafe-fil.io)
 * [Slack Channel for Updates: #fil-network-announcements](https://filecoinproject.slack.com/archives/C01AC6999KQ)
 * [Slack Channel for Questions: #fil-help](https://filecoinproject.slack.com/archives/CEGN061C5)
 * [Latest lightweight snapshot](https://forest-archive.chainsafe.dev/latest/calibnet/) generated with [Forest](http://github.com/ChainSafe/forest) by [ChainSafe](https://chainsafe.io/)

--- a/networks/calibration/README.md
+++ b/networks/calibration/README.md
@@ -57,7 +57,7 @@ The following storage providers are running on the Calibration testnet.
 
 ## Resources <a href="#resources" id="resources"></a>
 
-* [Calibration Faucet - Zondax](https://faucet.calibnet.chainsafe-fil.io)
+* [Calibration Faucet - Chainsafe](https://faucet.calibnet.chainsafe-fil.io)
 * [Calibration Faucet - Zondax](https://beryx.zondax.ch/faucet/)
 * [DataCap allocation](https://faucet.calibnet.chainsafe-fil.io)
 * [Slack Channel for Updates: #fil-network-announcements](https://filecoinproject.slack.com/archives/C01AC6999KQ)

--- a/smart-contracts/developing-contracts/get-test-tokens.md
+++ b/smart-contracts/developing-contracts/get-test-tokens.md
@@ -12,7 +12,7 @@ description: >-
 MetaMask is one of the easier ways to manage addresses on the Calibration testnet. MetaMask uses the `t4` [address type](../filecoin-evm-runtime/address-types.md), which allows developers to create and manage Solidity contracts easily. Follow the [MetaMask setup guide](../../basics/assets/metamask-setup.md) if you havn’t set up an address in your MetaMask wallet yet.
 
 1. In your browser, open MetaMask and copy your address to your clipboard.
-2. Go to [faucet.calibration.fildev.network](https://faucet.calibration.fildev.network/) and click **Send Funds**.
+2. Go to [faucet.calibnet.chainsafe-fil.io](https://faucet.calibnet.chainsafe-fil.io) and click **Send Funds**.
 3. Paste your address into the address field and click **Send funds**:
 
     ![The Calibration faucet website.](../../.gitbook/assets/smart-contracts-developing-contracts-get-test-tokens-send-funds.png)

--- a/smart-contracts/developing-contracts/solidity-libraries.md
+++ b/smart-contracts/developing-contracts/solidity-libraries.md
@@ -51,7 +51,7 @@ Let’s take an ERC20 contract as an example to write and deploy it on the Calib
 * Remix.
 * MetaMask.
 * [MetaMask connected to the Calibration testnet](../../networks/calibration/).
-* Test tokens (tFIL) [from the faucet](https://faucet.calibration.fildev.network/funds.html).
+* Test tokens (tFIL) [from the faucet](https://faucet.calibnet.chainsafe-fil.io).
 
 **Procedure**
 

--- a/smart-contracts/fundamentals/erc-20-quickstart.md
+++ b/smart-contracts/fundamentals/erc-20-quickstart.md
@@ -64,7 +64,7 @@ Nice! Now we’ve got the Filecoin Calibration testnet set up within MetaMask. Y
 1.  In your browser, open MetaMask and copy your address to your clipboard:
 
     ![Copy your address to your clipboard.](../../.gitbook/assets/smart-contracts-fundamentals-erc-20-quickstart-faucet-get-address.webp)
-2. Go to [faucet.calibration.fildev.network](https://faucet.calibration.fildev.network/) and click **Send Funds.**
+2. Go to [faucet.calibration.chainsafe-fil.io](https://faucet.calibnet.chainsafe-fil.io) and click **Send Funds.**
 3. Paste your address into the address field, and click **Send Funds**.
 4. The faucet will show a transaction ID. You can copy this ID into a Calibration testnet [block explorer](../../networks/calibration/explorers.md) to view your transaction. After a couple of minutes, you should see some `tFIL` transferred to your address.
 


### PR DESCRIPTION
The calibration infra has been moved to ChainSafe. This updates the faucet links in the docs to the correct address.