### PR TITLE
Update erc-20-quickstart.md

### DIFF
--- a/smart-contracts/fundamentals/erc-20-quickstart.md
+++ b/smart-contracts/fundamentals/erc-20-quickstart.md
@@ -39,9 +39,9 @@ Before we can interact with the Filecoin network, we need funds. But before we c
 
 ### Switch networks
 
-You may notice that we are currently connected to the **Ethereum Mainnet**. We need to point MetaMask to the Filecoin network, specifically the [Calibration testnet](../../networks/calibration/). We’ll use a website called [chainlist.network](https://chainlist.network) to give MetaMask the information it needs quickly.
+You may notice that we are currently connected to the **Ethereum Mainnet**. We need to point MetaMask to the Filecoin network, specifically the [Calibration testnet](../../networks/calibration/). We’ll use a website called [chainlist.org](https://chainlist.org) to give MetaMask the information it needs quickly.
 
-1. Go to [chainlist.network](https://chainlist.network).
+1. Go to [chainlist.org](https://chainlist.org).
 2.  Enable the **Testnets** toggle and enter `Filecoin` into the search bar.
 
     ![Search for Filecoin testnets in Chainlist.](../../.gitbook/assets/smart-contracts-fundamentals-erc-20-quickstart-chainlist-search.webp)


### PR DESCRIPTION
update the url for chainlist. The old one (https://chainlist.network/) is not working any more. 