### PR TITLE
Update check-external-links.yml

### DIFF
--- a/.github/workflows/check-external-links.yml
+++ b/.github/workflows/check-external-links.yml
@@ -14,5 +14,5 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v1.8.0
         with:
-          args: --accept 200,429,403 '**/*.md'
+          args: --accept 200,429,403 --timeout 60 --retry-wait-time 15 --max-retries 10 '**/*.md'
           fail: true


### PR DESCRIPTION
Since there are always false alarms on the external link checking process, let's try to increase the time out and retry times for the checker. 