### PR TITLE
Fixing all current broken links 

### DIFF
--- a/networks/mainnet/rpcs.md
+++ b/networks/mainnet/rpcs.md
@@ -6,7 +6,7 @@ description: Public RPC endpoints are available for the Filecoin mainnet.
 
 [Chainlist](https://chainlist.org/?search=filecoin&testnets=true) provides a dynamically updated list of [available Filecoin - Mainnet RPCs](https://chainlist.org/?search=filecoin&testnets=false).
 
-These endpoints are limited to the read-only [Filecoin JSON RPC API](../../reference/json-rpc/) including read-only [Filecoin Eth RPC](../../reference/json-rpc/eth) methods, except for the write operations [`MPoolPush`](../../reference/json-rpc/mpool.md#mpoolpush) and [`EthSendRawTransaction`](../../reference/json-rpc/eth#ethsendrawtransaction) for sending already signed messages.
+These endpoints are limited to the read-only [Filecoin JSON RPC API](../../reference/json-rpc/) including read-only [Filecoin Eth RPC](../../reference/json-rpc/eth.md) methods, except for the write operations [`MPoolPush`](../../reference/json-rpc/mpool.md#mpoolpush) and [`EthSendRawTransaction`](../../reference/json-rpc/eth.md#ethsendrawtransaction) for sending already signed messages.
 
 {% hint style="info" %} Please note that most publicly hosted endpoints <strong>only guarantee recent state, i.e. 2000 of the latest blocks (last 16.67 hours).</strong> To request an archival node you can contact a provider below. {% endhint %}
 

--- a/networks/mainnet/rpcs.md
+++ b/networks/mainnet/rpcs.md
@@ -6,9 +6,9 @@ description: Public RPC endpoints are available for the Filecoin mainnet.
 
 [Chainlist](https://chainlist.org/?search=filecoin&testnets=true) provides a dynamically updated list of [available Filecoin - Mainnet RPCs](https://chainlist.org/?search=filecoin&testnets=false).
 
-These endpoints are limited to [read-only Filecoin JSON RPC API calls](../../reference/json-rpc/) including [Filecoin Eth RPC methods](../../reference/json-rpc/eth.d).  The only write operation are [`MPoolPush`](../../reference/json-rpc/mpool.md#mpoolpush) and [`EthSendRawTransaction`](../../reference/json-rpc/eth.md#ethsendrawtransaction)for sending already signed messages.
+These endpoints are limited to the read-only [Filecoin JSON RPC API](../../reference/json-rpc/) including read-only [Filecoin Eth RPC](../../reference/json-rpc/eth) methods, except for the write operations [`MPoolPush`](../../reference/json-rpc/mpool.md#mpoolpush) and [`EthSendRawTransaction`](../../reference/json-rpc/eth.md#ethsendrawtransaction) for sending already signed messages.
 
-{% hint style="info" %} Please note that most publicly hosted endpoints **only guarantee recent state, i.e. 2000 of the latest blocks (last 16.67 hours).** To request an archival node you can contact a provider below. {% endhint %}
+{% hint style="info" %} Please note that most publicly hosted endpoints <strong>only guarantee recent state, i.e. 2000 of the latest blocks (last 16.67 hours).</strong> To request an archival node you can contact a provider below. {% endhint %}
 
 
 <table>

--- a/networks/mainnet/rpcs.md
+++ b/networks/mainnet/rpcs.md
@@ -6,7 +6,7 @@ description: Public RPC endpoints are available for the Filecoin mainnet.
 
 [Chainlist](https://chainlist.org/?search=filecoin&testnets=true) provides a dynamically updated list of [available Filecoin - Mainnet RPCs](https://chainlist.org/?search=filecoin&testnets=false).
 
-These endpoints are limited to the read-only [Filecoin JSON RPC API](../../reference/json-rpc/) including read-only [Filecoin Eth RPC](../../reference/json-rpc/eth) methods, except for the write operations [`MPoolPush`](../../reference/json-rpc/mpool.md#mpoolpush) and [`EthSendRawTransaction`](../../reference/json-rpc/eth.md#ethsendrawtransaction) for sending already signed messages.
+These endpoints are limited to the read-only [Filecoin JSON RPC API](../../reference/json-rpc/) including read-only [Filecoin Eth RPC](../../reference/json-rpc/eth) methods, except for the write operations [`MPoolPush`](../../reference/json-rpc/mpool.md#mpoolpush) and [`EthSendRawTransaction`](../../reference/json-rpc/eth#ethsendrawtransaction) for sending already signed messages.
 
 {% hint style="info" %} Please note that most publicly hosted endpoints <strong>only guarantee recent state, i.e. 2000 of the latest blocks (last 16.67 hours).</strong> To request an archival node you can contact a provider below. {% endhint %}
 

--- a/smart-contracts/fundamentals/README.md
+++ b/smart-contracts/fundamentals/README.md
@@ -44,9 +44,9 @@ Let’s get building. Choose one of the following APIs. These are all storage he
 
 Examples:
 
-* [Polygon tutorial](https://nftschool.dev/tutorial/mint-nftstorage-polygon/) on NFTschool.dev
-* [Flow tutorial](https://nftschool.dev/tutorial/flow-nft-marketplace/) on NFTschool.dev
-* [Avalanche tutorial](https://nftschool.dev/tutorial/avax-nft/) on NFTschool.dev
+* [Polygon tutorial](https://github.com/protocol/nft-website/blob/main/docs/tutorial/mint-nftstorage-polygon.md)
+* [Flow tutorial](https://github.com/protocol/nft-website/blob/main/docs/tutorial/flow-nft-marketplace.md) 
+* [Avalanche tutorial](https://github.com/protocol/nft-website/blob/main/docs/tutorial/avax-nft.md) 
 * [Using IPFS & Filecoin on Harmony](https://docs.harmony.one/home/developers/tutorials/ipfs-filecoin)
 
 ## Additional resources

--- a/storage-providers/filecoin-deals/filecoin-programs.md
+++ b/storage-providers/filecoin-deals/filecoin-programs.md
@@ -69,7 +69,7 @@ Swan is a provider of cross-chain cloud computing solutions. Developers can use 
 
 Swan Cloud provides decentralized cloud computing solutions for Web3 projects by integrating storage, computing, and payment into one suite.
 
-### [Open Panda](https://openpanda.io/)
+### [Open Panda](https://github.com/data-preservation-programs/open-panda)
 
 Open Panda was a platform for data researchers, analysts, students, and enthusiasts to interact with the largest open datasets in the world. Data available through the platform was stored on Filecoin, a decentralized storage network comprised of thousands of independent Storage Providers around the world.
 

--- a/storage-providers/filecoin-economics/fil-collateral.md
+++ b/storage-providers/filecoin-economics/fil-collateral.md
@@ -38,7 +38,7 @@ The “Current Sector Initial Pledge" can be found on blockchain explorers like 
 
 Another cost factor in the network is gas. Storage providers not only pledge collateral for the capacity they announce on-chain. The network also burns FIL in the form of gas fees. Most activity on-chain has some level of gas involved. For storage providers, this is the case for committing sectors.
 
-The gas fees fluctuate over time and can be followed on various websites like [FGas](https://fgas.io/).
+The gas fees fluctuate over time and can be followed on various websites like [Filfox - Gas Statistics](https://filfox.info/en/stats/gas) and [Beryx - Gas Estimator](https://beryx.io/estimate_gas).
 
 ## FIL lending programs
 


### PR DESCRIPTION
In lieu of https://github.com/filecoin-project/filecoin-docs/issues/2319 for now

Someone really needs to fix these things once per month and do a better job of keeping links updated