### PR TITLE
Adding Lava RPC endpoints to Filecoin documentation

### DIFF
--- a/networks/calibration/rpcs.md
+++ b/networks/calibration/rpcs.md
@@ -42,6 +42,10 @@ FULLNODE_API_INFO=wss://wss.calibration.node.glif.io/apigw/lotus lotus daemon --
 * When using a lite-node, omit `/rpc/v1` from Glif’s WebSocket address.
 * [Glif documentation](https://hosting.glif.io/)
 
+## [Lava](https://docs.lavanet.xyz/filecoin)
+
+* HTTPS: `https://filecoin-testnet.lava.build`
+* [Lava documentation](https://docs.lavanet.xyz/filecoin-dev)
 
 
 [Was this page helpful?](https://airtable.com/apppq4inOe4gmSSlk/pagoZHC2i1iqgphgl/form?prefill\_Page+URL=https://docs.filecoin.io/networks/calibration/rpcs)

--- a/networks/mainnet/rpcs.md
+++ b/networks/mainnet/rpcs.md
@@ -21,6 +21,7 @@ In order to check the current benchmarked performance of each of the below endpo
 | [Chainup Cloud](https://cloud.chainup.com/) | `https://filecoin.chainup.net/rpc/v1`                    | `wss://filecoin.chainup.net/rpc/v1`              | [Chainup Cloud Docs - Filecoin](https://docs.chainupcloud.com/blockchain-api/filecoin/public-apis) |                                                           |
 | [NOWNodes](https://nownodes.io/)            | `https://fil.nownodes.io` (Free for 1 month with signup) |                                                  | [NOWNodes - Docs](https://documenter.getpostman.com/view/13630829/TVmFkLwy)                        |                                                           |
 | [GetBlock](https://getblock.io/nodes/fil)   | `https://filecoin.getblock.io` (Free with signup)        |                                                  | [GetBlock - Docs](https://getblock.io/docs/getblock-explorer/get-started/)                         |                                                           |
+| [Lava](https://docs.lavanet.xyz/filecoin-dev)   | `https://filecoin.lava.build`                            |                                                  | [Docs](https://docs.lavanet.xyz/filecoin-dev)                                                          | JSON RPC                                                  |
 
 ## Additional Notes:
 

--- a/networks/mainnet/rpcs.md
+++ b/networks/mainnet/rpcs.md
@@ -21,7 +21,7 @@ In order to check the current benchmarked performance of each of the below endpo
 | [Chainup Cloud](https://cloud.chainup.com/) | `https://filecoin.chainup.net/rpc/v1`                    | `wss://filecoin.chainup.net/rpc/v1`              | [Chainup Cloud Docs - Filecoin](https://docs.chainupcloud.com/blockchain-api/filecoin/public-apis) |                                                           |
 | [NOWNodes](https://nownodes.io/)            | `https://fil.nownodes.io` (Free for 1 month with signup) |                                                  | [NOWNodes - Docs](https://documenter.getpostman.com/view/13630829/TVmFkLwy)                        |                                                           |
 | [GetBlock](https://getblock.io/nodes/fil)   | `https://filecoin.getblock.io` (Free with signup)        |                                                  | [GetBlock - Docs](https://getblock.io/docs/getblock-explorer/get-started/)                         |                                                           |
-| [Lava](https://docs.lavanet.xyz/filecoin-dev)   | `https://filecoin.lava.build`                            |                                                  | [Docs](https://docs.lavanet.xyz/filecoin-dev)                                                          | JSON RPC                                                  |
+| [Lava](https://docs.lavanet.xyz/filecoin-dev)   | `https://filecoin.lava.build`                            |                                                  | [Lava - Docs](https://docs.lavanet.xyz/filecoin-dev)                                                          | JSON RPC                                                  |
 
 ## Additional Notes:
 


### PR DESCRIPTION
This pull request adds new Lava RPC endpoints to the Filecoin documentation. Specifically:

- Added Lava mainnet and testnet endpoints under the relevant sections in the RPC documentation.
- Updated the table and listed the HTTPS endpoints for Lava, along with the corresponding documentation links.

These changes aim to provide developers and users with additional RPC options for interacting with Filecoin mainnet and testnet.

Please review and let me know if any adjustments are needed.