### PR TITLE
docs: Update spin-up-a-lite-node.md

### DIFF
--- a/nodes/lite-nodes/spin-up-a-lite-node.md
+++ b/nodes/lite-nodes/spin-up-a-lite-node.md
@@ -7,7 +7,7 @@ description: >-
 
 # Spin up a lite-node
 
-In this guide, we will use the [Lotus](../implementations/lotus.md) Filecoin implementation to install a lite-node on MacOS and Ubuntu. For other Linux distributions, check out the [Lotus documentation](https://lotus.filecoin.io/lotus/install/linux/#building-from-source). To run a lite-node on Windows, install [WLS with Ubuntu](https://ubuntu.com/tutorials/install-ubuntu-on-wsl2-on-windows-10#1-overview) on your system and follow the _Ubuntu_ instructions below.
+In this guide, we will use the [Lotus](../implementations/lotus.md) Filecoin implementation to install a lite-node on MacOS and Ubuntu. For other Linux distributions, check out the [Lotus documentation](https://lotus.filecoin.io/lotus/install/linux/#building-from-source). To run a lite-node on Windows, install [WSL with Ubuntu](https://ubuntu.com/tutorials/install-ubuntu-on-wsl2-on-windows-10#1-overview) on your system and follow the _Ubuntu_ instructions below.
 
 ## Prerequisites
 


### PR DESCRIPTION
update with minor typo at [Spin up a lite-node](uhttps://docs.filecoin.io/nodes/lite-nodes/spin-up-a-lite-noderl) page

![image](https://github.com/user-attachments/assets/e8a1eaa4-16fc-4aff-9ee3-ac3b44298610)
