### PR TITLE
Fix remove synchronize from github action

### DIFF
--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -3,7 +3,7 @@ name: Update Lotus Version
 on:
   workflow_dispatch:  # Allows manual trigger
   pull_request:
-    types: [opened, reopened, synchronize]
+    types: [opened, reopened]
 
 jobs:
   update-version:


### PR DESCRIPTION
After this change, the workflow will only run when PRs are `opened` or `reopened`, but not when there is a new commit (`synchronize`).
