### PR TITLE
Update rpcs.md

### DIFF
--- a/networks/calibration/rpcs.md
+++ b/networks/calibration/rpcs.md
@@ -18,14 +18,7 @@ These endpoints are limited to [read-only Filecoin JSON RPC API calls](../../ref
 ## [ChainupCloud](https://cloud.chainup.com)
 
 * HTTPS: `https://filecoin-calibration.chainup.net/rpc/v1`
-* WebSocket: `wss://filecoin-calibration.chainup.net/rpc/v1`
 * [ChainupCloud documentation](https://docs.chainupcloud.com/blockchain-api/filecoin/public-apis)
-
-## [dRPC](https://drpc.org/chainlist/filecoin)
-
-* HTTPS: `https://filecoin.drpc.org`
-* WebSocket: `wss://filecoin.drpc.org`
-* [dRPC documentation](https://docs.drpc.org/)
 
 ## [Glif](https://api.calibration.node.glif.io)
 


### PR DESCRIPTION
Removed drpc as they seem to have removed RPCS for filecoin.

Removed chainup websocket, as they only offer HTTP on calibnet now