### PR TITLE
Add FIP-0100 guidance

### DIFF
--- a/storage-providers/basics/README.md
+++ b/storage-providers/basics/README.md
@@ -36,7 +36,7 @@ You need to understand the various earning mechanisms in the Filecoin network.
 
 ### Daily fees and startup readiness (FIP-0100)
 
-With the activation of [FIP-0100](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0100.md) in network version 25, all new sectors - and any sectors that are extended or updated - incur a daily fee.
+With the activation of [FIP-0100](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0100.md) in network version 25, all new sectors — and any sectors that are extended or updated — incur a daily fee.
 
 This fee replaces the previous batch fee model and introduces a predictable cost structure tied to each sector’s quality-adjusted power and the network’s circulating supply.
 
@@ -48,6 +48,7 @@ Fee debt does not directly cause faults. However, it can impact operations:
 
 - A miner with fee debt may be blocked from submitting certain messages (e.g., pre-commits or recoveries).
 - If the balance is too low to pay for WindowPoSt messages, sectors may fault.
+- Critically, a miner with outstanding fee debt cannot win block rewards until the debt is repaid.
 
 To avoid this, storage providers should:
 
@@ -58,7 +59,7 @@ To avoid this, storage providers should:
 
 Miners become eligible to win block rewards once they reach **10 TiB of raw byte power (RBP)**.
 
-However, rewards are not guaranteed as soon as that threshold is met. Block production is probabilistic, and smaller miners may wait longer to win a block - especially when competing against larger ones.
+However, rewards are not guaranteed as soon as that threshold is met. Block production is probabilistic, and smaller miners may wait longer to win a block — especially when competing against larger ones.
 
 This creates a funding gap during the startup phase.
 
@@ -68,7 +69,9 @@ New storage providers must plan for this by funding their miner actor with enoug
 - Support message submission (like WindowPoSt),
 - And continue sealing until rewards start arriving.
 
-While the amount of FIL required is relatively small compared to overall infrastructure costs, it is operationally critical. Without it, the miner may become stuck - unable to seal new sectors or submit required messages due to fee debt or insufficient balance.
+While the amount of FIL required is relatively small compared to overall infrastructure costs, it is operationally critical. Without it, the miner may become stuck — unable to seal new sectors, submit required messages, or produce blocks and win block rewards due to fee debt or insufficient balance.
+
+To estimate how much FIL may be needed, review the [FIP-0100 discussion thread](https://github.com/filecoin-project/FIPs/discussions/1105) or use the [real-time fee calculator](https://penalty.660688.xyz/dailyfee) to model your expected onboarding rate.
 
 ## Make sure you have the right skills <a href="#make-sure-you-have-the-right-skills" id="make-sure-you-have-the-right-skills"></a>
 

--- a/storage-providers/basics/README.md
+++ b/storage-providers/basics/README.md
@@ -34,6 +34,42 @@ You need to understand the various earning mechanisms in the Filecoin network.
 
 [Filecoin deals ->](../filecoin-deals/storage-deals.md)
 
+### Daily fees and startup readiness (FIP-0100)
+
+With the activation of [FIP-0100](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0100.md) in network version 25, all new sectors - and any sectors that are extended or updated - incur a daily fee.
+
+This fee replaces the previous batch fee model and introduces a predictable cost structure tied to each sector’s quality-adjusted power and the network’s circulating supply.
+
+The fee begins accruing the day after a sector is committed or extended. It is deducted automatically at the end of each proving deadline.
+
+The network first draws from vesting block rewards. If those are insufficient, it draws from the miner’s available balance. If both are empty, the unpaid amount becomes **fee debt**.
+
+Fee debt does not directly cause faults. However, it can impact operations:
+
+- A miner with fee debt may be blocked from submitting certain messages (e.g., pre-commits or recoveries).
+- If the balance is too low to pay for WindowPoSt messages, sectors may fault.
+
+To avoid this, storage providers should:
+
+- Keep a FIL buffer in the miner actor’s balance.
+- Avoid fully withdrawing unlocked funds unless upcoming rewards will cover future fees.
+
+### Startup considerations
+
+Miners become eligible to win block rewards once they reach **10 TiB of raw byte power (RBP)**.
+
+However, rewards are not guaranteed as soon as that threshold is met. Block production is probabilistic, and smaller miners may wait longer to win a block - especially when competing against larger ones.
+
+This creates a funding gap during the startup phase.
+
+New storage providers must plan for this by funding their miner actor with enough FIL to:
+
+- Cover daily fees during onboarding,
+- Support message submission (like WindowPoSt),
+- And continue sealing until rewards start arriving.
+
+While the amount of FIL required is relatively small compared to overall infrastructure costs, it is operationally critical. Without it, the miner may become stuck - unable to seal new sectors or submit required messages due to fee debt or insufficient balance.
+
 ## Make sure you have the right skills <a href="#make-sure-you-have-the-right-skills" id="make-sure-you-have-the-right-skills"></a>
 
 As will become clear, running a storage operation is a serious business, with client data and pledged funds at stake. You will be required to run a highly-available service, and there are automatic financial penalties if you cannot demonstrate data availability to the network. There are many things that can go wrong in a data center, on your network, on your OS, or at an application level.
@@ -52,6 +88,4 @@ Take availability and suitable redundancy into consideration when choosing your 
 
 [Infrastructure ->](../skills/storage.md)
 
-
-
-[Was this page helpful?](https://airtable.com/apppq4inOe4gmSSlk/pagoZHC2i1iqgphgl/form?prefill\_Page+URL=https://docs.filecoin.io/storage-providers/basics)
+[Was this page helpful?](https://airtable.com/apppq4inOe4gmSSlk/pagoZHC2i1iqgphgl/form?prefill_Page+URL=https://docs.filecoin.io/storage-providers/basics)


### PR DESCRIPTION
Adds a new section to the Storage Provider Basics page explaining daily fees introduced in FIP-0100. Covers how fees are charged, fee debt behaviour, and startup readiness considerations for new SPs, including the 10 TiB threshold and delayed block rewards. Based on internal guidance and FIPs discussion thread #1105.