### PR TITLE
Add keywords to multiple documentation files for improved SEO and discoverability

### DIFF
--- a/basics/assets/the-fil-token.md
+++ b/basics/assets/the-fil-token.md
@@ -2,6 +2,7 @@
 description: >-
   FIL is the cryptocurrency that powers the Filecoin network. This page explains
   what FIL is, how it can be used, and its denominations.
+keywords: "FIL token, FIL cryptocurrency, Filecoin token, what is FIL, FIL coin, get FIL"
 ---
 
 # The FIL token

--- a/basics/how-storage-works/filecoin-and-ipfs.md
+++ b/basics/how-storage-works/filecoin-and-ipfs.md
@@ -71,7 +71,7 @@ The code that runs both clients and storage providers is open-source. Storage pr
 
 #### Active community
 
-Filecoin has an active community of contributors to answer questions and help newcomers get started. There is an open dialog between users, developers, and storage providers. If you need help, you can reach the person who designed or built the system in question. Reach out on [Filecoin’s chat and forums](https://docs.filecoin.io/basics/project-and-community/chat-and-discussion-forums/).
+Filecoin has an active community of contributors to answer questions and help newcomers get started. There is an open dialog between users, developers, and storage providers. If you need help, you can reach the person who designed or built the system in question. Reach out on [Filecoin’s chat and forums](https://docs.filecoin.io/basics/project-and-community/forums-and-fips).
 
 
 

--- a/basics/project-and-community/forums-and-FIPs.md
+++ b/basics/project-and-community/forums-and-FIPs.md
@@ -11,7 +11,7 @@ description: >-
 
 For shorter-lived discussions, our community chat open to all on both Slack and Discord:
 
-* [Slack](https://filecoinproject.slack.com)
+* [Slack](https://filecoin.io/slack/)
 * [Discord](https://discord.com/invite/filecoin)
 
 For long-lived discussions and for support, please use the [discussion tab on GitHub](https://github.com/filecoin-project/community#forums) instead of Slack. It’s easy for complex discussions to get lost in a sea of new messages on those chat platforms, and posting longer discussions and support requests on the forums helps future visitors, too.

--- a/basics/project-and-community/forums-and-FIPs.md
+++ b/basics/project-and-community/forums-and-FIPs.md
@@ -37,4 +37,4 @@ Typically, the FIP lifecycle looks something like this:
 
 It is the authors' responsibility to request status updates for the FIP.  A more robust explainer of the FIP process can be found in [FIP001](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0001.md#what-is-a-fip).
 
-[Was this page helpful?](https://airtable.com/apppq4inOe4gmSSlk/pagoZHC2i1iqgphgl/form?prefill\_Page+URL=https://docs.filecoin.io/basics/project-and-community/chat-and-discussion-forums)
+[Was this page helpful?](https://airtable.com/apppq4inOe4gmSSlk/pagoZHC2i1iqgphgl/form?prefill\_Page+URL=https://docs.filecoin.io/basics/project-and-community/forums-and-fips)

--- a/basics/project-and-community/forums-and-FIPs.md
+++ b/basics/project-and-community/forums-and-FIPs.md
@@ -11,7 +11,7 @@ description: >-
 
 For shorter-lived discussions, our community chat open to all on both Slack and Discord:
 
-* [Slack](https://filecoin.io/slack/)
+* [Slack](https://filecoin.io/slack)
 * [Discord](https://discord.com/invite/filecoin)
 
 For long-lived discussions and for support, please use the [discussion tab on GitHub](https://github.com/filecoin-project/community#forums) instead of Slack. It’s easy for complex discussions to get lost in a sea of new messages on those chat platforms, and posting longer discussions and support requests on the forums helps future visitors, too.

--- a/basics/project-and-community/forums-and-FIPs.md
+++ b/basics/project-and-community/forums-and-FIPs.md
@@ -5,34 +5,34 @@ description: >-
   of choice.
 ---
 
-# Discussion Forums and Filecoin Improvement Proposals 
+# Discussion Forums and Filecoin Improvement Proposals
 
 ### Discussion Forums
 
-For shorter-lived discussions, our community chat open to all on both Slack and Discord: 
+For shorter-lived discussions, our community chat open to all on both Slack and Discord:
 
-* [Slack](https://filecoin.io/slack/)
+* [Slack](https://filecoinproject.slack.com)
 * [Discord](https://discord.com/invite/filecoin)
 
 For long-lived discussions and for support, please use the [discussion tab on GitHub](https://github.com/filecoin-project/community#forums) instead of Slack. It’s easy for complex discussions to get lost in a sea of new messages on those chat platforms, and posting longer discussions and support requests on the forums helps future visitors, too.
 
 ### Filecoin improvement proposals
 
-Filecoin improvement proposals (FIPs) are design documents that propose changes and improvements to the Filecoin network, giving detailed specifications and their rational, and allowing the community to document their consensus or dissent.  All technical FIPs that are accepted are later reflected in the [Filecoin Spec](https://spec.filecoin.io/). 
+Filecoin improvement proposals (FIPs) are design documents that propose changes and improvements to the Filecoin network, giving detailed specifications and their rational, and allowing the community to document their consensus or dissent.  All technical FIPs that are accepted are later reflected in the [Filecoin Spec](https://spec.filecoin.io/).
 
-There are three types of FIPs: 
+There are three types of FIPs:
 * Technical FIPs (FTP): protocol changes, standards, API changes.  They can include core (consensus-related changes, networking (network protocol improvements, interface (API/RPC or language-level updates), or can be informational (updates to general guidelines or documentation).
 * Organizational FIPs (FOP): changes to processes, tools, or governance.
 * Recovery FIPs (FRP): emergency fixes requiring state changes (e.g., major bugs).
 
-Typically, the FIP lifecycle looks something like this: 
+Typically, the FIP lifecycle looks something like this:
 
 [ WIP ] -> [ DRAFT ] -> [ LAST CALL ] -> [ ACCEPTED ] -> [ FINAL ]
 
-1. WIP: A community member has an idea for a FIP, and begins discussing the idea publicly on the Filecoin Discord, in the [Filecoin Slack channel for discussing FIPs](https://filecoinproject.slack.com/archives/C01EU76LPCJ), or in Github issues for the relevant repo.  
+1. WIP: A community member has an idea for a FIP, and begins discussing the idea publicly on the Filecoin Discord, in the [Filecoin Slack channel for discussing FIPs](https://filecoinproject.slack.com/archives/C01EU76LPCJ), or in Github issues for the relevant repo.
 2. DRAFT: If there is a chance the FIP could be adopted, the author submits a draft for the FIP as a pull request in the [FIPs repo](https://github.com/filecoin-project/FIPs).
 3. LAST CALL: This status allows the community to submit final changes to the draft.
-4. ACCEPTED: Once the FIP is voted on and accepted, the core engineers will work to implement it.  
+4. ACCEPTED: Once the FIP is voted on and accepted, the core engineers will work to implement it.
 5. FINAL: This status represents the current state-of-the-art, and it should only be updated to correct errors.
 
 It is the authors' responsibility to request status updates for the FIP.  A more robust explainer of the FIP process can be found in [FIP001](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0001.md#what-is-a-fip).

--- a/networks/calibration/README.md
+++ b/networks/calibration/README.md
@@ -2,6 +2,7 @@
 description: >-
   The calibration network is the most realistic testnet simulation of the
   Filecoin mainnet.
+keywords: "calibration testnet, calibnet, Filecoin testnet, test FIL, faucet, storage provider testing, deal making testnet, 32 GiB sectors, 64 GiB sectors, lotus daemon, bootstrap peers, genesis block, network parameters, WindowPoSt, sector sealing, snapshot, forest snapshot, calibration snapshot, download snapshot"
 ---
 
 # Calibration

--- a/networks/calibration/README.md
+++ b/networks/calibration/README.md
@@ -10,6 +10,49 @@ description: >-
 Also see [Calibration RPCs](rpcs.md) and [Calibration Explorers](explorers.md).
 {% endhint %}
 
+The calibration network is the most realistic testnet simulation of the Filecoin mainnet.
+
+## Quick Start Commands
+
+### Download Latest Snapshot
+```bash
+# Fast download with aria2c (recommended)
+aria2c -x5 https://forest-archive.chainsafe.dev/latest/calibnet/
+
+# Alternative: wget method
+wget https://forest-archive.chainsafe.dev/latest/calibnet/
+```
+
+### Connect to Calibration Network
+
+```bash
+# Lite node (fastest startup)
+FULLNODE_API_INFO=wss://wss.calibration.node.glif.io/apigw/lotus lotus daemon --lite
+
+# Full node with snapshot import
+lotus daemon --import-snapshot <snapshot-file>
+
+# Connect to RPC endpoint
+curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"Filecoin.ChainHead","params":[],"id":1}' https://api.calibration.node.glif.io/rpc/v1
+```
+
+### Get Test FIL
+
+Quick access to faucets:
+
+* **Chainsafe**: https://faucet.calibnet.chainsafe-fil.io
+* **Zondax**: https://beryx.zondax.ch/faucet/
+* **Forest**: https://forest-explorer.chainsafe.dev/faucet/calibnet
+
+### Essential Network Info
+
+* **Chain ID**: `314159` (for MetaMask/wallets)
+* **RPC**: `https://api.calibration.node.glif.io/rpc/v1`
+* **WebSocket**: `wss://wss.calibration.node.glif.io/apigw/lotus/rpc/v1`
+* **Minimum Power**: `32 GiB`
+
+## About Calibration
+
 Prospective storage providers can experience more realistic sealing performance and hardware requirements using final proofs constructions and parameters. Storage clients can store and retrieve _real data_ on the network. Clients can also participate in deal-making workflows and storage and retrieval functionality. The sector size on the Calibration testnet is the same as on the Filecoin mainnet; 32 GiB and 64 GiB sectors are supported. This testnet also includes the Filecoin EVM-runtime features found on the Filecoin mainnet.
 
 Developers can reference pre-existing deals that are already available on the network. See the [`#fil-net-calibration-discuss` channel in the Filecoin Slack](https://filecoinproject.slack.com/archives/C01D42NNLMS) for support.

--- a/networks/calibration/README.md
+++ b/networks/calibration/README.md
@@ -30,7 +30,7 @@ wget https://forest-archive.chainsafe.dev/latest/calibnet/
 FULLNODE_API_INFO=wss://wss.calibration.node.glif.io/apigw/lotus lotus daemon --lite
 
 # Full node with snapshot import
-lotus daemon --import-snapshot <snapshot-file>
+lotus daemon --import-snapshot <calibnet-snapshot-file>
 
 # Connect to RPC endpoint
 curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"Filecoin.ChainHead","params":[],"id":1}' https://api.calibration.node.glif.io/rpc/v1

--- a/smart-contracts/filecoin-evm-runtime/how-gas-works.md
+++ b/smart-contracts/filecoin-evm-runtime/how-gas-works.md
@@ -3,6 +3,8 @@ description: >-
   Instead of assigning a fixed gas cost in each instruction, the Filecoin EVM
   runtime charges FIL gas based on the WASM code execution of the Filecoin EVM
   runtime interpreter.
+keywords: "filecoin gas, gas calculation, gas estimation, gas fees, how gas works, EVM gas"
+
 ---
 
 # How gas works
@@ -35,13 +37,13 @@ Let’s take a transaction as an example. Our gas parameters are:
 The total fee is `(GasUsage × BaseFee) + (Gaslimit x GasPremium)`:
 
 ```plaintext
-   1000 
+   1000
 x    20
 = 20000
 
-   2000 
-x     5 
-= 10000 
+   2000
+x     5
+= 10000
 
   20000
 + 10000

--- a/smart-contracts/fundamentals/support.md
+++ b/smart-contracts/fundamentals/support.md
@@ -8,9 +8,9 @@ description: >-
 
 ## Slack
 
-Like many other distributed teams, the Filecoin developer relations, lead by the [FIL Builders](https://fil.builders/) team, works mostly on Slack and Discord. You can join the Filecoin Project Slack for free by going to [`filecoin.io/slack`](https://filecoin.io/slack/) and the Discord by going to [https://discord.com/invite/filecoin](https://discord.com/invite/filecoin).  
+Like many other distributed teams, the Filecoin developer relations, lead by the [FIL Builders](https://fil.builders/) team, works mostly on Slack and Discord. You can join the Filecoin Project Slack for free by going to [`filecoin.io/slack`](https://filecoin.io/slack) and the Discord by going to [https://discord.com/invite/filecoin](https://discord.com/invite/filecoin).
 
-The following Slack channels are most relevant for Filecoin builders: 
+The following Slack channels are most relevant for Filecoin builders:
 
 * [`#fil-builders`](https://filecoinproject.slack.com/archives/CRK2LKYHW) for building solutions on FVM and Filecoin
 * [`#fil-fvm-dev`](https://filecoinproject.slack.com/archives/C029MT4PQB1) for development of the FVM

--- a/storage-providers/basics/README.md
+++ b/storage-providers/basics/README.md
@@ -3,6 +3,7 @@ description: >-
   This page will help you understand how to plan a profitable business, design a
   suitable storage provider architecture, and make the right hardware
   investments.
+keywords: "earn FIL, Filecoin rewards, storage provider rewards, stake FIL, staking FIL, Filecoin staking, become storage provider, FIL staking alternative"
 ---
 
 # Basics


### PR DESCRIPTION

## Description
The intention of this PR is to enhance the likelihood that these pages are surfaced more effectively in both external search engines and GitHub’s internal search.


### Search queries and suggestion for 1st result in Quick Find 

Table also available in the ticket - [link here](https://www.notion.so/filecoin/Filecoin-Docs-Look-into-search-setting-for-most-searched-keywords-1dd7631f282580768c34f1e055f04ea6?source=copy_link) 

eventSearchQuery | eventsCount | visitorsCount | 1st result | Suggestion for the 1st result
-- | -- | -- | -- | --
gas | 12 | 7 | Gas | https://docs.filecoin.io/smart-contracts/filecoin-evm-runtime/how-gas-works Would be better than the JSON-RPC reference
staking | 11 | 10 | Networks | This should point to Glif or a page about defi staking 
stake | 8 | 7 | State | This should point to Glif or a page about defi staking
snapshot | 8 | 7 | Callibration | https://lotus.filecoin.io/lotus/install/start-lotus/#download-snapshot I realise this isn’t on docs.filecoin.io but I forgot this aria2c -x5 <https://forest-archive.chainsafe.dev/latest/mainnet/> command all the time and need it
fil | 7 | 5 | Filecoin.sol | https://docs.filecoin.io/basics/assets/the-fil-token

## Important Note

1. Please note that these changes **do not guarantee that the targeted pages will be prioritized in internal search results**. As stated in the documentation:
“_[We do not currently support the ability to prioritize certain content in Quick find results.](https://gitbook.com/docs/creating-content/searching-your-content/quick-find#display-of-results)_”

Adding keywords may help with SEO, but for true prioritization within internal search, we would need to consider content rework.

2. Regarding the `snapshot` comment - I've asked Claude to integrate the command instructions in the content, **please double check** 😅
