### PR TITLE
change update versions workflow to a cron job

### DIFF
--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -1,9 +1,10 @@
 name: Update Lotus Version
 
 on:
+  schedule:
+    # Run every 2 days at 03:47 UTC
+    - cron: '47 3 */2 * *'
   workflow_dispatch:
-  pull_request:
-    types: [opened, reopened]
 
 jobs:
   update-version:


### PR DESCRIPTION
- remove  pull request trigger
- set cron job to random time to avoid being dropped by github if midnight has too many scheduled jobs