### PR TITLE
Update install-and-run-curio.md

### DIFF
--- a/storage-providers/pdp/install-and-run-curio.md
+++ b/storage-providers/pdp/install-and-run-curio.md
@@ -31,7 +31,6 @@ Clone the repository and switch to the PDP branch:
 ```sh
 git clone https://github.com/filecoin-project/curio.git
 cd curio
-git checkout synapse
 ```
 
 {% hint style="info" %}


### PR DESCRIPTION
Synapse branch checkout is no longer required. Users should default to main.