### PR TITLE
Revert "Running linkchecker on top of latest main instead of an old fork"

### DIFF
--- a/.github/workflows/check-external-links.yml
+++ b/.github/workflows/check-external-links.yml
@@ -8,13 +8,7 @@ jobs:
   linkChecker:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code (merge of PR + base)
-        uses: actions/checkout@v4
-        with:
-          # For pull_request events, this is the "virtual" merge commit
-          # If the PR can't be merged (conflicts), this ref won't exist.
-          ref: ${{ github.event_name == 'pull_request' && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.ref }}
-          fetch-depth: 0
+      - uses: actions/checkout@v3
 
       - name: Link Checker
         id: lychee


### PR DESCRIPTION
Reverts filecoin-project/filecoin-docs#2410