### PR TITLE
remove dangerous secure_path from docs

### DIFF
--- a/storage-providers/pdp/install-and-run-pdp.md
+++ b/storage-providers/pdp/install-and-run-pdp.md
@@ -84,16 +84,6 @@ You should see something like: `rustc 1.86.0 (05f9846f8 2025-03-31)`
 
 ***
 
-### 🔐 Add Go and Rust to Secure Sudo Path
-
-```sh
-sudo tee /etc/sudoers.d/dev-paths <<EOF
-Defaults secure_path="/usr/local/go/bin:$HOME/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-EOF
-```
-
-***
-
 ## ⛓️ Installing and Running Lotus
 
 🧠 Lotus is your gateway to the Filecoin network. It syncs the chain, manages wallets, and is required for Curio to interact with your node.


### PR DESCRIPTION
currently the docs suggest adding the user's rust bin to secure_path

there appears no reason, explicit or implicit, to do so, you should not build as root, you should generally not put user-writeable dirs in secure_path, and the specific ordering of the PATH here is dangerous on top

alternatively, please provide an explanation for why this is needed and (ideally) reorder to put the user bin at the end