### PR TITLE
docs(filecoin-pin): mainnet GA updates and PR review feedback

### DIFF
--- a/builder-cookbook/filecoin-pin/dapp-demo.md
+++ b/builder-cookbook/filecoin-pin/dapp-demo.md
@@ -21,7 +21,7 @@ In this walkthrough, you’ll build a simple drag-and-drop file uploader that:
 
 ## Setup
 
-We will start building by [forking the *filecoin-pin-website demo repo](https://github.com/filecoin-project/filecoin-pin-website/fork).* Make sure you have **Node.js 18+** and **npm 9+** installed.  The dapp works with Filecoin Calibration testnet. 
+We will start building by [forking the *filecoin-pin-website demo repo](https://github.com/filecoin-project/filecoin-pin-website/fork).* Make sure you have **Node.js 24+** and **npm 9+** installed.  The dapp works with Filecoin Calibration testnet. 
 
 This will take ~10min. ⏲️
 
@@ -108,4 +108,4 @@ That is it - you now have a dapp with a drag-and-drop interface to store IPFS Fi
 1. Check back on the [filecoin-pin-website repo](https://github.com/filecoin-project/filecoin-pin-website) - it will continue to be updated as new functionality is brought to filecoin-pin.
 2. Feel free to report any issues with the dApp demo to https://github.com/filecoin-project/filecoin-pin-website/issues
 3. Check out the the [other example uses of filecoin-pin](../).
-4. Ask questions or get help with filecoin-pin in the [supported communcation channels](https://github.com/filecoin-project/filecoin-pin?tab=readme-ov-file#support-info).
+4. Ask questions or get help with filecoin-pin in the [supported communication channels](https://github.com/filecoin-project/filecoin-pin?tab=readme-ov-file#community-and-support).

--- a/builder-cookbook/filecoin-pin/erc-8004-agent-registration.md
+++ b/builder-cookbook/filecoin-pin/erc-8004-agent-registration.md
@@ -52,7 +52,7 @@ Before starting, you'll need:
 
 1. **Filecoin Pin CLI** - Follow the complete setup guide here:
    - [Filecoin Pin Getting Started](getting-started.md)
-   - This covers wallet creation, testnet tokens (tFIL and USDFC), and payment setup
+   - This covers wallet creation, funding your wallet with FIL and USDFC, and payment setup
 
 2. **Foundry** - Ethereum development toolkit for contract interactions
    ```bash

--- a/builder-cookbook/filecoin-pin/erc-8004-agent-registration.md
+++ b/builder-cookbook/filecoin-pin/erc-8004-agent-registration.md
@@ -51,7 +51,7 @@ Agent cards need persistent storage with provable guarantees. Unlike generic IPF
 Before starting, you'll need:
 
 1. **Filecoin Pin CLI** - Follow the complete setup guide here:
-   - [Filecoin Pin Getting Started](https://docs.filecoin.io/builder-cookbook/filecoin-pin/getting-started)
+   - [Filecoin Pin Getting Started](getting-started.md)
    - This covers wallet creation, testnet tokens (tFIL and USDFC), and payment setup
 
 2. **Foundry** - Ethereum development toolkit for contract interactions
@@ -599,19 +599,19 @@ View on explorer: [Base Mainnet Registry](https://basescan.org/address/0x8004A16
 
 ### Upload to Filecoin Mainnet
  
-All Filecoin Pin CLI commands use the `--mainnet` flag for mainnet operations.
+Filecoin Pin defaults to Mainnet, so no extra flags are needed for mainnet operations.
 
 #### Setup Payment System (Mainnet)
 
 ```bash
 export PRIVATE_KEY="0x..."  # Your wallet private key
-filecoin-pin payments setup --auto --mainnet
+filecoin-pin payments setup --auto
 ```
 
 #### Upload Your Agent Card (Mainnet)
 
 ```bash
-filecoin-pin add --auto-fund --mainnet github-agent-card.json
+filecoin-pin add --auto-fund github-agent-card.json
 ```
 
 Save the **Root CID** and **Dataset ID** from the output.
@@ -653,7 +653,7 @@ echo "Agent ID: $AGENT_ID"
 ### Check Mainnet Storage Proofs
 
 ```bash
-filecoin-pin data-set show <YOUR_DATASET_ID> --mainnet
+filecoin-pin data-set show <YOUR_DATASET_ID>
 ```
 
 ***

--- a/builder-cookbook/filecoin-pin/faq.md
+++ b/builder-cookbook/filecoin-pin/faq.md
@@ -8,14 +8,11 @@ Filecoin Pin stores IPFS content on the Filecoin Network of decentralized Storag
 
 ### How can I use Filecoin Pin today?
 
-Two paths are available:
+Three paths are available:
 
-* **Website:** Upload files in your browser. Uses a pre-funded test wallet.
-* **CLI:** Upload files from your terminal. Fund storage from your own wallet.
-
-{% hint style="info" %}
-Both run on Calibration testnet. They use tFIL and USDFC. Data has no persistence guarantees while on Calibnet.
-{% endhint %}
+* **CLI:** Upload files from your terminal on Filecoin Mainnet. Fund storage from your own wallet. [Get started here](getting-started.md).
+* **GitHub Action:** Automate pinning of websites or build artifacts in your CI/CD pipeline.
+* **Website (demo):** Upload files in your browser using a pre-funded test wallet on Calibration testnet.
 
 ***
 
@@ -27,8 +24,8 @@ Both run on Calibration testnet. They use tFIL and USDFC. Data has no persistenc
 
 ### How do payments and approvals work?
 
-* **Website:** The demo wallet handles payments. It has been prefunded with testnet USDFC and FIL. Users don't need to connect their own wallet.
-* **CLI:** Your test wallet handles payments. You approve and deposit funds through Filecoin Pay.
+* **Website (demo):** The demo wallet handles payments. It has been prefunded with testnet USDFC and FIL. Users don't need to connect their own wallet.
+* **CLI / GitHub Action:** Your wallet handles payments on Mainnet. You approve and deposit USDFC funds through Filecoin Pay once, then the CLI manages payments automatically.
 
 {% hint style="info" %}
 Storage providers receive payment after cryptographically proving data possession.
@@ -48,9 +45,9 @@ No manual deposit calculations needed. The system handles it.
 
 ### How long is my data stored?
 
-This runs on Calibration testnet only. Treat it as a demo. No duration guarantees exist for Website or CLI.
+On **Mainnet** (the default), data persists as long as you maintain deposits in Filecoin Pay. Storage providers must prove they hold your data daily or they stop receiving payment. The CLI supports auto-funding to keep your runway healthy.
 
-Mainnet will offer persistence guarantees. Data persists while you maintain deposits. The CLI supports auto-funding for storage.
+On **Calibration testnet** (the demo website), data has no persistence guarantees. Treat it as a demo environment only.
 
 ***
 

--- a/builder-cookbook/filecoin-pin/getting-started.md
+++ b/builder-cookbook/filecoin-pin/getting-started.md
@@ -11,7 +11,7 @@ This guide walks you through pinning your first file to Filecoin using the Filec
 * ✅ Install the Filecoin Pin CLI
 * ✅ Connect your Ethereum-style wallet on Filecoin
 * ✅ Deposit storage credit on Filecoin Pay
-* ✅ Pin a file to Filecoin and retrieve it via IPFS standard tooling
+* ✅ Pin a file to Filecoin and retrieve it using standard IPFS tooling
 
 ***
 
@@ -241,7 +241,7 @@ You can also retrieve it programmatically using any IPFS-compatible client (Kubo
 
 ## 🛡️ Inspect your storage proofs
 
-Filecoin storage providers must cryptographically prove multiple times per day that they continue to store your data. You can inspect those proofs and the on-chain payment rails at any time.
+Filecoin storage providers must cryptographically prove daily that they continue to store your data. You can inspect those proofs and the on-chain payment rails at any time.
 
 List the data sets associated with your wallet:
 

--- a/builder-cookbook/filecoin-pin/getting-started.md
+++ b/builder-cookbook/filecoin-pin/getting-started.md
@@ -11,7 +11,7 @@ This guide walks you through pinning your first file to Filecoin using the Filec
 * ✅ Install the Filecoin Pin CLI
 * ✅ Connect your Ethereum-style wallet on Filecoin
 * ✅ Deposit storage credit on Filecoin Pay
-* ✅ Pin a file to Filecoin and retrieve it via IPFS
+* ✅ Pin a file to Filecoin and retrieve it via IPFS standard tooling
 
 ***
 
@@ -22,7 +22,7 @@ Before starting, make sure you have:
 * **An Ethereum-style wallet on Filecoin** - MetaMask is the easiest option. If you don't have one set up, see [Wallets](../../basics/assets/wallets.md) and [Metamask setup](../../basics/assets/metamask-setup.md).
 * **FIL in your wallet** - to pay transaction gas fees on Filecoin.
 * **USDFC in your wallet** - to pay for storage. USDFC is the stablecoin used by Filecoin Onchain Cloud. The easiest way to get some is to [swap FIL for USDFC on Sushi](https://www.sushi.com/filecoin/swap?token0=NATIVE&token1=0x80b98d3aa09ffff255c3ba4a241111ff1262f045).
-* **Node.js 22 or later** - the Filecoin Pin CLI runs on Node.js. Install from [nodejs.org](https://nodejs.org/) or via your package manager.
+* **Node.js 24 or later** - the Filecoin Pin CLI runs on Node.js. Install from [nodejs.org](https://nodejs.org/) or via your package manager.
 
 <table data-view="cards"><thead><tr><th></th><th data-hidden></th><th data-hidden data-card-target data-type="content-ref"></th></tr></thead><tbody><tr><td>Filecoin Pin Repository</td><td><a href="https://github.com/filecoin-project/filecoin-pin">https://github.com/filecoin-project/filecoin-pin</a></td><td><a href="https://github.com/filecoin-project/filecoin-pin">https://github.com/filecoin-project/filecoin-pin</a></td></tr><tr><td>Filecoin Pin Support Channels</td><td><a href="https://filecoinproject.slack.com/archives/C07CGTXHHT4">Filecoin Slack - #fil-foc</a></td><td><a href="https://filecoinproject.slack.com/archives/C07CGTXHHT4">https://filecoinproject.slack.com/archives/C07CGTXHHT4</a></td></tr></tbody></table>
 
@@ -171,7 +171,7 @@ filecoin-pin payments status
 Now you're ready to pin. Create a test file:
 
 ```sh
-echo "Hello Filecoin Pin!" > demo.txt
+echo "Hello Filecoin Pin @ $(date)!" > demo.txt
 ```
 
 Pin it to Filecoin:
@@ -184,8 +184,8 @@ The CLI will:
 
 1. Pack your file into IPFS-compatible format (a CAR file).
 2. Select storage providers automatically.
-3. Upload your file to two providers for redundancy.
-4. Verify the upload was advertised on the IPFS network indexer.
+3. Store your file with two providers for redundancy.
+4. Verify the upload was advertised to [IPNI indexers](https://github.com/filecoin-project/filecoin-pin/blob/master/documentation/glossary.md#ipni).
 
 {% hint style="success" %}
 You should see something like:
@@ -221,7 +221,7 @@ filecoin-pin add my-data/
 
 ## 🌐 Retrieve your file
 
-Your file is now retrievable via any IPFS Mainnet gateway using its Root CID. For example:
+Your file is now retrievable via standard IPFS tooling using its Root CID. For example:
 
 ```
 https://<YOUR_ROOT_CID>.ipfs.inbrowser.link
@@ -241,7 +241,7 @@ You can also retrieve it programmatically using any IPFS-compatible client (Kubo
 
 ## 🛡️ Inspect your storage proofs
 
-Filecoin storage providers must cryptographically prove daily that they continue to store your data. You can inspect those proofs and the on-chain payment rails at any time.
+Filecoin storage providers must cryptographically prove multiple times per day that they continue to store your data. You can inspect those proofs and the on-chain payment rails at any time.
 
 List the data sets associated with your wallet:
 
@@ -307,6 +307,7 @@ You've successfully pinned your first file to Filecoin. You now have:
 ## 🔜 Next Steps
 
 * 📖 Run `filecoin-pin --help` to explore advanced usage, including auto-funding and custom provider selection.
+* 🔍 Want to understand what's happening behind the scenes? Read [Behind the Scenes of Adding a File](https://github.com/filecoin-project/filecoin-pin/blob/master/documentation/behind-the-scenes-of-adding-a-file.md) for a deep dive into each step.
 * 🤖 Automate pinning in your CI/CD pipeline with the [Filecoin Pin GitHub Action](github-action.md).
 * 💬 Join the community in Filecoin Slack [#fil-foc](https://filecoinproject.slack.com/archives/C07CGTXHHT4) for help, discussion, and updates.
 * 🐛 Found a bug or have a feature request? [Open an issue](https://github.com/filecoin-project/filecoin-pin/issues) on GitHub.


### PR DESCRIPTION
## Summary

Follow-up to filecoin-project/filecoin-docs#2459, incorporating BigLep's review feedback and additional improvements for mainnet GA framing.

**getting-started.md**
- Node.js 22 → 24 (aligns with filecoin-pin requirement)
- "retrieve it via IPFS" → "via IPFS standard tooling"
- Demo file uses `$(date)` so content is unique per run (avoids content-addressing "just works" effect)
- "Upload your file to two providers" → "Store your file with two providers for redundancy"
- Added IPNI link to step 4
- "retrievable via any IPFS Mainnet gateway" → "via standard IPFS tooling"
- "prove daily" → "prove multiple times per day"
- Added "Behind the Scenes of Adding a File" link in Next Steps

**faq.md**
- "How can I use Filecoin Pin today?" — mainnet-first: CLI/GitHub Action on Mainnet, website as demo
- "How long is my data stored?" — leads with Mainnet persistence guarantees, Calibration as demo-only

**erc-8004-agent-registration.md**
- Relative link for Getting Started (per BigLep's nit)
- Removed invalid `--mainnet` flag from all CLI commands (mainnet is the default, no flag needed)

**dapp-demo.md**
- Node.js 18+ → 24+
- Fixed broken `#support-info` anchor → `#community-and-support`
- Fixed typo: "communcation" → "communication"

## Test plan

- [ ] Review Getting Started guide end-to-end for accuracy
- [ ] Confirm FAQ mainnet framing is correct
- [ ] Verify relative links in erc-8004 doc resolve correctly in GitBook

🤖 Generated with [Claude Code](https://claude.com/claude-code)