### PR TITLE
docs: fix stale links for link checker

### DIFF
--- a/basics/how-retrieval-works/saturn.md
+++ b/basics/how-retrieval-works/saturn.md
@@ -6,7 +6,7 @@ description: >-
 
 # Saturn
 
-<figure><img src="../../.gitbook/assets/basics-how-retrieval-works-saturn-saturn-homepage (1).webp" alt=""><figcaption><p><a href="https://saturn.tech/">https://saturn.tech/</a></p></figcaption></figure>
+<figure><img src="../../.gitbook/assets/basics-how-retrieval-works-saturn-saturn-homepage (1).webp" alt=""><figcaption><p><a href="https://github.com/filecoin-saturn">https://github.com/filecoin-saturn</a></p></figcaption></figure>
 
 Saturn is a Web3 CDN in Filecoin’s retrieval market. On one side of the network, websites buy fast, low-cost content delivery. On the other side, Saturn node operators earn Filecoin by fulfilling requests.
 
@@ -16,7 +16,7 @@ Content on Saturn is IPFS content-addressed. Every piece of content is immutable
 
 Incentives unite, align, and grow the network. Node operators earn Filecoin for accelerating web content, and websites get faster content delivery for less.
 
-Find out more over at [saturn.tech](https://saturn.tech).
+Find out more at the [Filecoin Saturn GitHub organization](https://github.com/filecoin-saturn).
 
 
 

--- a/basics/how-storage-works/filecoin-plus.md
+++ b/basics/how-storage-works/filecoin-plus.md
@@ -67,8 +67,8 @@ The steps a client should follow to acquire DataCap are as follows:
 
 1. Create a [Filecoin wallet](https://docs.filecoin.io/basics/assets/wallets).
 2. Choose an allocator from the [full list of active allocators](https://github.com/filecoin-project/Allocator-registry) or the [active list of allocators](https://allocator.tech/) who have verified public datasets.
-3. Check that you satisfy the requirements of the allocator. In the case of uploading open source datasets with FIDL as the allocator, the client will need to demonstrate to FIDL that they can (1) satisfy a third party Know Your Customer(KYC) identity check, (2) provide the details of storage provider (entity, storage location) where the data is intended to be stored, and (3) demonstrate proof that the dataset can be actively retrieved. You can learn more about [FIDL’s requirements and application process](https://www.fidl.tech/apply-for-datacap).
-4. Submit an application for DataCap from an allocator. You can submit a request to FIDL via their [Github application form](https://github.com/fidlabs/Open-Data-Pathway/issues/new/choose) or [Google Form](https://www.fidl.tech/apply-for-datacap).
+3. Check that you satisfy the requirements of the allocator. In the case of uploading open source datasets with FIDL as the allocator, the client will need to demonstrate to FIDL that they can (1) satisfy a third party Know Your Customer(KYC) identity check, (2) provide the details of storage provider (entity, storage location) where the data is intended to be stored, and (3) demonstrate proof that the dataset can be actively retrieved. You can learn more about FIDL’s requirements and application process in their [GitHub application form](https://github.com/fidlabs/Open-Data-Pathway/issues/new/choose).
+4. Submit an application for DataCap from an allocator. You can submit a request to FIDL via their [GitHub application form](https://github.com/fidlabs/Open-Data-Pathway/issues/new/choose).
 5. Use the DataCap in a storage deal.
 
 ### Steps to Acquire Testnet DataCap as a Builder

--- a/basics/how-storage-works/storage-onramps.md
+++ b/basics/how-storage-works/storage-onramps.md
@@ -13,7 +13,7 @@ The available storage onramps are:
 * [Lighthouse](https://lighthouse.storage/) "offers permanent, decentralized storage powered by Filecoin. Secure, scalable, and ideal for individuals, developers, and enterprises."
 * [Akave](https://www.akave.ai/) is "revolutionizing data management with a decentralized, modular solution that combines the robust storage of Filecoin with cutting-edge encryption and easy-to-use interfaces."  
 * [Storacha](https://storacha.network/) is an open hot storage network scales IPFS and Filecoin. Upload any data and Storacha will ensure it ends up on a decentralized set of IPFS and Filecoin storage providers. There Storacha [docs](https://docs.storacha.network/) detail the JavaScript and Go API libraries, and there is a no-code web uploader available as well.
-* [Singularity](https://data-programs.gitbook.io/singularity) "facilitates onboarding of large quantaties of data (PB-scale) to the Filecoin network in an efficient, secure, and flexible way."
+* [Singularity](https://data-programs.gitbook.io/singularity) "facilitates onboarding of large quantities of data (PB-scale) to the Filecoin network in an efficient, secure, and flexible way."
 * [CID Gravity](https://www.cidgravity.com/) is a "seamless gateway to the decentralized web", allowing you to drag and drop files through an easy-to-use UI that uploads files to Filecoin and IPFS.  
 * [Ramo](https://use.ramo.computer/) provides Filecoin-based, S3-compatible storage for data on Filecoin.
 

--- a/basics/how-storage-works/storage-onramps.md
+++ b/basics/how-storage-works/storage-onramps.md
@@ -13,8 +13,8 @@ The available storage onramps are:
 * [Lighthouse](https://lighthouse.storage/) "offers permanent, decentralized storage powered by Filecoin. Secure, scalable, and ideal for individuals, developers, and enterprises."
 * [Akave](https://www.akave.ai/) is "revolutionizing data management with a decentralized, modular solution that combines the robust storage of Filecoin with cutting-edge encryption and easy-to-use interfaces."  
 * [Storacha](https://storacha.network/) is an open hot storage network scales IPFS and Filecoin. Upload any data and Storacha will ensure it ends up on a decentralized set of IPFS and Filecoin storage providers. There Storacha [docs](https://docs.storacha.network/) detail the JavaScript and Go API libraries, and there is a no-code web uploader available as well.
-* [Singularity](https://singularity.storage/) "facilitates onboarding of large quantaties of data (PB-scale) to the Filecoin network in an efficient, secure, and flexible way."
+* [Singularity](https://data-programs.gitbook.io/singularity) "facilitates onboarding of large quantaties of data (PB-scale) to the Filecoin network in an efficient, secure, and flexible way."
 * [CID Gravity](https://www.cidgravity.com/) is a "seamless gateway to the decentralized web", allowing you to drag and drop files through an easy-to-use UI that uploads files to Filecoin and IPFS.  
-* [Ramo](https://www.ramo.io/) is "a network coordinating people, hardware and capital to build a more open and resilient internet infrastructure for everyone."  
+* [Ramo](https://use.ramo.computer/) provides Filecoin-based, S3-compatible storage for data on Filecoin.
 
 [Was this page helpful?](https://airtable.com/apppq4inOe4gmSSlk/pagoZHC2i1iqgphgl/form?prefill\_Page+URL=https://docs.filecoin.io/basics/how-storage-works/storage-onramps)

--- a/basics/project-and-community/filecoin-faqs.md
+++ b/basics/project-and-community/filecoin-faqs.md
@@ -33,7 +33,7 @@ We think that the internet must return to its _decentralized roots_ to be resili
 
 We are still finalizing our cryptoeconomic parameters, and they will continue to evolve.
 
-Here is a blog about Filecoin economics from December 2020: [Filecoin network economics](https://filecoin.io/blog/posts/filecoin-network-economics/).
+Here is a blog about Filecoin economics from December 2020: [Filecoin network economics](https://filecoin.io/blog/filecoin-network-economics/).
 
 #### How expensive will Filecoin storage be at launch?
 
@@ -95,7 +95,7 @@ AMD may be optimal hardware for SDR. You can [see this description](https://gith
 
 #### How are you working on bootstrapping the demand side of the marketplace? The Discover program is nice, but who is the target market for users, and how do you get them?
 
-In addition to [Filecoin Discover](https://filecoin.io/blog/posts/introducing-filecoin-discover/), a number of groups are actively building tools and services to support the adoption of the Filecoin network with developers and clients. For example, check out the recordings from our [Virtual Community Meetup](https://filecoin.io/blog/filecoin-virtual-community-meetup-recap/) to see updates about Textile and Starling Storage. You can also read more about some of the teams building on Filecoin through HackFS in our [HackFS Week 1 Recap](https://filecoin.io/blog/hackfs-teams-vol-1/).
+In addition to [Filecoin Discover](https://filecoin.io/blog/introducing-filecoin-discover/), a number of groups are actively building tools and services to support the adoption of the Filecoin network with developers and clients. For example, check out the recordings from our [Virtual Community Meetup](https://filecoin.io/blog/filecoin-virtual-community-meetup-recap/) to see updates about Textile and Starling Storage. You can also read more about teams building on Filecoin through the [HackFS event](https://ethglobal.com/events/hackfs).
 
 #### Does Filecoin have an implementation of client and storage provider order matching through order books?
 

--- a/basics/project-and-community/forums-and-FIPs.md
+++ b/basics/project-and-community/forums-and-FIPs.md
@@ -11,7 +11,7 @@ description: >-
 
 For shorter-lived discussions, our community chat open to all on both Slack and Discord:
 
-* [Slack](https://filecoin.io/slack)
+* [Slack](https://filecoinproject.slack.com/ssb/redirect)
 * [Discord](https://discord.com/invite/filecoin)
 
 For long-lived discussions and for support, please use the [discussion tab on GitHub](https://github.com/filecoin-project/community#forums) instead of Slack. It’s easy for complex discussions to get lost in a sea of new messages on those chat platforms, and posting longer discussions and support requests on the forums helps future visitors, too.

--- a/basics/project-and-community/social-media.md
+++ b/basics/project-and-community/social-media.md
@@ -16,7 +16,7 @@ Explore the latest news, events and other happenings on the official [Filecoin B
 
 ### Newsletter
 
-Subscribe to the [Filecoin newsletter](https://filecoin.io/build/#events) for official project updates sent straight to your inbox.
+Follow the [Filecoin blog](https://filecoin.io/blog/) and [Filecoin events](https://fil.org/events) for official project updates.
 
 ### Twitter
 

--- a/basics/project-and-community/social-media.md
+++ b/basics/project-and-community/social-media.md
@@ -14,7 +14,7 @@ The [Filecoin YouTube channel](https://www.youtube.com/channel/UCPyYmtJYQwxM-EUy
 
 Explore the latest news, events and other happenings on the official [Filecoin Blog](https://filecoin.io/blog/).
 
-### Newsletter
+### Updates
 
 Follow the [Filecoin blog](https://filecoin.io/blog/) and [Filecoin events](https://fil.org/events) for official project updates.
 

--- a/basics/project-and-community/ways-to-contribute.md
+++ b/basics/project-and-community/ways-to-contribute.md
@@ -39,7 +39,7 @@ If you have never contributed to an open-source project before, or just need a r
 
 #### Community
 
-If interacting with people is your favorite thing to do in this world, join the [Filecoin chat and discussion forums](forums-and-FIPs.md) to say hello, meet others who share your goals, and connect with other members of the community. You should also consider joining [Filecoin Slack](https://filecoin.io/slack).
+If interacting with people is your favorite thing to do in this world, join the [Filecoin chat and discussion forums](forums-and-FIPs.md) to say hello, meet others who share your goals, and connect with other members of the community. You should also consider joining [Filecoin Slack](https://filecoinproject.slack.com/ssb/redirect).
 
 #### Build Applications
 
@@ -48,7 +48,7 @@ Filecoin is designed for you to integrate into your own applications and service
 Get started by looking at the list of projects currently built on Filecoin. Build anything you think is missing! If you’re unsure about something, you can join the chat and discussion forums to get help or feedback on your specific problem/idea. You can also join a Filecoin Hackathon, apply for a Filecoin Developer Grant or apply to the Filecoin accelerator program to support the development of your project.
 
 * [Filecoin Hackathons](https://hackathons.filecoin.io/)
-* [Filecoin Developer Grants](https://filecoin.io/grants/)
+* [Filecoin Developer Grants](https://www.fil.org/grants)
 * [Filecoin Accelerator Program](https://ecosystem-wg.notion.site/Protocol-Labs-Accelerator-Program-d45d8792a7d544eca9beb7d3e3d3b05d)
 
 #### Protocol Design

--- a/basics/what-is-filecoin/programming-on-filecoin.md
+++ b/basics/what-is-filecoin/programming-on-filecoin.md
@@ -7,7 +7,7 @@ description: >-
 
 ## Compute-over-data
 
-Beyond storage and retrieval, data often needs transformation. Compute-over-data protocols enable computations over IPLD, the data layer used by content-addressed systems like Filecoin. Working groups are developing compute solutions for Filecoin data, including large-scale parallel compute (e.g., [Bacalhau](https://www.bacalhau.org/)) and cryptographically verifiable compute (e.g., [Lurk](https://filecoin.io/blog/posts/introducing-lurk-a-programming-language-for-recursive-zk-snarks/)).
+Beyond storage and retrieval, data often needs transformation. Compute-over-data protocols enable computations over IPLD, the data layer used by content-addressed systems like Filecoin. Working groups are developing compute solutions for Filecoin data, including large-scale parallel compute (e.g., [Bacalhau](https://www.bacalhau.org/)) and cryptographically verifiable compute (e.g., [Lurk](https://filecoin.io/blog/introducing-lurk-a-programming-language-for-recursive-zk-snarks/)).
 
 For example, Bacalhau provides a platform for public, transparent, and verifiable distributed computation, allowing users to run Docker containers and WebAssembly (Wasm) images as tasks on data stored in InterPlanetary File System (IPFS).
 

--- a/builder-cookbook/data-storage/retrieve-data.md
+++ b/builder-cookbook/data-storage/retrieve-data.md
@@ -18,7 +18,7 @@ With a given CID, you can use any of the following retrieval clients to retrieve
 
 * [Lassie](https://github.com/filecoin-project/lassie): optimizes for most efficient available retrieval protocols.
   * [go-car](https://github.com/ipld/go-car): a content addressable archive utility.
-* [Saturn](https://saturn.tech/): a Web3 CDN in Filecoin’s retrieval market.
+* [Saturn](https://github.com/filecoin-saturn): a Web3 CDN in Filecoin’s retrieval market.
 
 #### **Instructions**
 

--- a/builder-cookbook/data-storage/store-data.md
+++ b/builder-cookbook/data-storage/store-data.md
@@ -244,7 +244,7 @@ import CID from "cids";
   };
 </code></pre>
 
-The full tutorial for uploading data using Lighthouse SDK and smart contract can be found [here](https://docs.lighthouse.storage/how-to/using-pdp-with-lighthouse).
+More information about Lighthouse storage tools is available in the [Lighthouse docs](https://docs.lighthouse.storage/).
 
 ***
 

--- a/reference/general/README.md
+++ b/reference/general/README.md
@@ -63,7 +63,7 @@ Web-based applications that store your data on Filecoin. No command-line or codi
 
 * [Lighthouse](https://lighthouse.storage/) "offers permanent, decentralized storage powered by Filecoin. Secure, scalable, and ideal for individuals, developers, and enterprises."
 * [Storacha](https://storacha.network/) is an open hot storage network scales IPFS and Filecoin. Upload any data and Storacha will ensure it ends up on a decentralized set of IPFS and Filecoin storage providers. There Storacha [docs](https://docs.storacha.network/) detail the JavaScript and Go API libraries, and there is a no-code web uploader available as well.
-* [Singularity](https://data-programs.gitbook.io/singularity) "facilitates onboarding of large quantaties of data (PB-scale) to the Filecoin network in an efficient, secure, and flexible way."
+* [Singularity](https://data-programs.gitbook.io/singularity) "facilitates onboarding of large quantities of data (PB-scale) to the Filecoin network in an efficient, secure, and flexible way."
 * [CID Gravity](https://www.cidgravity.com/) is a "seamless gateway to the decentralized web", allowing you to drag and drop files through an easy-to-use UI that uploads files to Filecoin and IPFS.  
 * [Ramo](https://use.ramo.computer/) provides Filecoin-based, S3-compatible storage for data on Filecoin.
 * [Starling Framework for Data Integrity](https://www.starlinglab.org/)

--- a/reference/general/README.md
+++ b/reference/general/README.md
@@ -9,7 +9,7 @@ description: >-
 ## About Filecoin
 
 * [**Filecoin Specification**](https://spec.filecoin.io/) - technical specification for Filecoin protocol and its associated subsystems.
-* [**Filecoin Slack**](https://filecoin.io/slack) - announcements and open discussion of Filecoin.
+* [**Filecoin Slack**](https://filecoinproject.slack.com/ssb/redirect) - announcements and open discussion of Filecoin.
 * [**Filecoin Orbit Community Program**](https://www.fil.org/orbit) - the Filecoin Orbit Community Program is an effort of dozens of volunteers around the world to organize meetups and hackathons in their local jurisdictions.
 * [**Filecoin YouTube channel**](https://www.youtube.com/channel/UCPyYmtJYQwxM-EUyRUTp5DA) - various Filecoin workshops, conference talks, and meetups.
 
@@ -32,7 +32,7 @@ description: >-
   * [Mainnet network status](https://filecoin.statuspage.io/) - reports the status and incident of the Filecoin Mainnet.
 * **Calibration**
   * Largest testnet which support 32 GiB and 64 GiB sectors.
-  * See [`#fil-net-calibration-discuss`](https://filecoinproject.slack.com/archives/C01D42NNLMS) for questions and discussion in [Filecoin Slack](https://filecoin.io/slack).
+  * See [`#fil-net-calibration-discuss`](https://filecoinproject.slack.com/archives/C01D42NNLMS) for questions and discussion in [Filecoin Slack](https://filecoinproject.slack.com/ssb/redirect).
 * **Local Devnet**
   * [Run a Local Devnet using Lotus](https://lotus.filecoin.io/lotus/developers/local-network/).
 
@@ -63,12 +63,12 @@ Web-based applications that store your data on Filecoin. No command-line or codi
 
 * [Lighthouse](https://lighthouse.storage/) "offers permanent, decentralized storage powered by Filecoin. Secure, scalable, and ideal for individuals, developers, and enterprises."
 * [Storacha](https://storacha.network/) is an open hot storage network scales IPFS and Filecoin. Upload any data and Storacha will ensure it ends up on a decentralized set of IPFS and Filecoin storage providers. There Storacha [docs](https://docs.storacha.network/) detail the JavaScript and Go API libraries, and there is a no-code web uploader available as well.
-* [Singularity](https://singularity.storage/) "facilitates onboarding of large quantaties of data (PB-scale) to the Filecoin network in an efficient, secure, and flexible way."
+* [Singularity](https://data-programs.gitbook.io/singularity) "facilitates onboarding of large quantaties of data (PB-scale) to the Filecoin network in an efficient, secure, and flexible way."
 * [CID Gravity](https://www.cidgravity.com/) is a "seamless gateway to the decentralized web", allowing you to drag and drop files through an easy-to-use UI that uploads files to Filecoin and IPFS.  
-* [Ramo](https://www.ramo.io/) is "a network coordinating people, hardware and capital to build a more open and resilient internet infrastructure for everyone."  
+* [Ramo](https://use.ramo.computer/) provides Filecoin-based, S3-compatible storage for data on Filecoin.
 * [Starling Framework for Data Integrity](https://www.starlinglab.org/)
   * to securely capture, store and verify human history
-  * learn more at [`starlinglab.org/78days`](https://www.starlinglab.org/78days/) or the [Filecoin blog interview](https://filecoin.io/blog/starling-framework/)
+  * learn more at [`starlinglab.org/78days`](https://www.starlinglab.org/78days/)
 
 ## APIs & Developer tools
 

--- a/smart-contracts/advanced/multisig.md
+++ b/smart-contracts/advanced/multisig.md
@@ -50,7 +50,7 @@ A web UI for the Safe multisig on Filecoin is available at:
 - **Executing a transaction** can produce gas estimation issues for accounts that have a very small amount of funds (that would not or would barely cover the transaction).
 - **Transaction confirmation times** may lead to prolonged "processing" status in the UI.
 - **Safe addresses from other networks** can sometimes be used but require additional technical steps.
-  - In some cases the same Safe address and owner structure is not possible, learn more in [this article](https://help.safe.global/en/articles/40812-i-sent-assets-to-a-safe-address-on-the-wrong-network-any-chance-to-recover).
+  - In some cases the same Safe address and owner structure is not possible.
   - Confirm complete creation (not just as a Placeholder) of the Safe multisig as an EVM contract on Filecoin prior to sending major funds.
   - Instructions for deploying a Safe at the same address on another chain are available in [this video](https://share.zight.com/z8uBKZYr). Note that a compatible version of the Safe Proxy on the original chain must exist on Filecoin. Contact Safe-related support for help.
   - If the previous address and chain use the L1 implementation of Safe Proxy, more complex technical migration steps will be required to map to the L2 version on Filecoin. Contact Safe-related support for more info.

--- a/smart-contracts/advanced/oracles.md
+++ b/smart-contracts/advanced/oracles.md
@@ -102,7 +102,6 @@ eOracle's smart contracts are live on the Filecoin Calibration testnet.
 
 * [eOracle docs](https://eoracle.gitbook.io/eoracle)
 * [eOracle GitHub](https://github.com/eoracle)
-* [eOracle Price Feed Integration Guide](https://eoracle.gitbook.io/eoracle/price-feeds/integration-guide)
 
 
 

--- a/smart-contracts/developing-contracts/solidity-libraries.md
+++ b/smart-contracts/developing-contracts/solidity-libraries.md
@@ -112,7 +112,7 @@ The DappSys library provides safe, simple, and flexible Ethereum contract buildi
 
 The 0x protocol library provides a set of secure smart contracts that facilitate peer-to-peer exchange of Ethereum-based assets.
 
-* [Documentation](https://docs.0x.org/introduction/introduction-to-0x)
+* [Documentation](https://0x.org/docs/introduction/0x-cheat-sheet)
 * [GitHub](https://github.com/0xProject)
 
 

--- a/smart-contracts/fundamentals/support.md
+++ b/smart-contracts/fundamentals/support.md
@@ -8,7 +8,7 @@ description: >-
 
 ## Slack
 
-Like many other distributed teams, the Filecoin developer relations, lead by the [FIL Builders](https://fil.builders/) team, works mostly on Slack and Discord. You can join the Filecoin Project Slack for free by going to [Filecoin Project Slack](https://filecoinproject.slack.com/ssb/redirect) and the Discord by going to [https://discord.com/invite/filecoin](https://discord.com/invite/filecoin).
+Like many other distributed teams, the Filecoin developer relations, led by the [FIL Builders](https://fil.builders/) team, works mostly on Slack and Discord. You can access the Filecoin Project Slack at [Filecoin Project Slack](https://filecoinproject.slack.com/ssb/redirect) and join the Discord at [https://discord.com/invite/filecoin](https://discord.com/invite/filecoin).
 
 The following Slack channels are most relevant for Filecoin builders:
 

--- a/smart-contracts/fundamentals/support.md
+++ b/smart-contracts/fundamentals/support.md
@@ -8,7 +8,7 @@ description: >-
 
 ## Slack
 
-Like many other distributed teams, the Filecoin developer relations, lead by the [FIL Builders](https://fil.builders/) team, works mostly on Slack and Discord. You can join the Filecoin Project Slack for free by going to [`filecoin.io/slack`](https://filecoin.io/slack) and the Discord by going to [https://discord.com/invite/filecoin](https://discord.com/invite/filecoin).
+Like many other distributed teams, the Filecoin developer relations, lead by the [FIL Builders](https://fil.builders/) team, works mostly on Slack and Discord. You can join the Filecoin Project Slack for free by going to [Filecoin Project Slack](https://filecoinproject.slack.com/ssb/redirect) and the Discord by going to [https://discord.com/invite/filecoin](https://discord.com/invite/filecoin).
 
 The following Slack channels are most relevant for Filecoin builders:
 

--- a/smart-contracts/fundamentals/the-fvm.md
+++ b/smart-contracts/fundamentals/the-fvm.md
@@ -13,7 +13,7 @@ NOTE: As of January 2025, for developer support, please visit the [FILB](https:/
 
 Filecoin’s storage and retrieval capabilities can be thought of as the base layer of the Filecoin blockchain, and [FVM](https://fvm.filecoin.io) can be thought of as a layer on top of Filecoin that unlocks programmability on the network (e.g. programmable storage primitives).
 
-Whereas other blockchains do have smart contract capabilities, FVM’s smart contracts can use Filecoin storage and retrieval primitives with computational logic conditions. FVM will also enable Layer 2 capabilities, such as “compute over data” and [content delivery networks](https://saturn.tech/).
+Whereas other blockchains do have smart contract capabilities, FVM’s smart contracts can use Filecoin storage and retrieval primitives with computational logic conditions. FVM will also enable Layer 2 capabilities, such as “compute over data” and [content delivery networks](https://github.com/filecoin-saturn).
 
 Some additional notes about FVM’s technical specifications:
 

--- a/storage-providers/architecture/network-indexer.md
+++ b/storage-providers/architecture/network-indexer.md
@@ -18,7 +18,7 @@ There are two groups of users within the network indexer process:
 
 This diagram summarizes the different _actors_ in the indexer ecosystem and how they interact with each other. In this context, these actors are not the same as [smart-contract actors](../../smart-contracts/filecoin-evm-runtime/actor-types.md).
 
-<figure><img src="../../.gitbook/assets/storage-providers-architecture-network-indexer-indexer.png" alt=""><figcaption><p>For more info on how the indexer works, read the <a href="https://filecoin.io/blog/posts/how-does-the-network-indexer-work/">Filecoin blog post</a>.</p></figcaption></figure>
+<figure><img src="../../.gitbook/assets/storage-providers-architecture-network-indexer-indexer.png" alt=""><figcaption><p>For more info on how the indexer works, read the <a href="https://filecoin.io/blog/how-does-the-network-indexer-work/">Filecoin blog post</a>.</p></figcaption></figure>
 
 ## IPNI and storage providers
 

--- a/storage-providers/basics/quickstart-guide.md
+++ b/storage-providers/basics/quickstart-guide.md
@@ -12,11 +12,11 @@ Get ready to dive into the valuable resources of the [storage provider documenta
 
 ## <img src="../../.gitbook/assets/storage-provider-basics-quickstart-guide-icon.png" alt="" data-size="line"> Gain insights into ROI and collateral’s role
 
-To run a successful storage provider business, it’s crucial to understand the concept of [Return on Investment (ROI)](https://calc.filecoin.eu) and the significance of collateral. By planning ahead and considering various factors, such as CAPEX, OPEX, network variables, and collateral requirements, you can make informed decisions that impact your business’s profitability and desired capacity.
+To run a successful storage provider business, it’s crucial to understand the concept of [Return on Investment (ROI)](../filecoin-deals/return-on-investment.md) and the significance of collateral. By planning ahead and considering various factors, such as CAPEX, OPEX, network variables, and collateral requirements, you can make informed decisions that impact your business’s profitability and desired capacity.
 
 ## <img src="../../.gitbook/assets/storage-provider-basics-quickstart-guide-icon.png" alt="" data-size="line"> Get to know the ecosystem
 
-One of the truly enriching elements of the Filecoin ecosystem lies in its vibrant community. Meet the community on the [Filecoin Slack](https://filecoin.io/slack). Within this dynamic network, you’ll find a treasure trove of individuals who are eager to share their experiences and offer invaluable solutions to the challenges they’ve encountered along the way. Whether it’s navigating the intricacies of storage provider operations or overcoming hurdles on the blockchain, this supportive community stands ready to lend a helping hand. Embrace the spirit of collaboration and tap into this remarkable network.
+One of the truly enriching elements of the Filecoin ecosystem lies in its vibrant community. Meet the community on the [Filecoin Slack](https://filecoinproject.slack.com/ssb/redirect). Within this dynamic network, you’ll find a treasure trove of individuals who are eager to share their experiences and offer invaluable solutions to the challenges they’ve encountered along the way. Whether it’s navigating the intricacies of storage provider operations or overcoming hurdles on the blockchain, this supportive community stands ready to lend a helping hand. Embrace the spirit of collaboration and tap into this remarkable network.
 
 ## <img src="../../.gitbook/assets/storage-provider-basics-quickstart-guide-icon.png" alt="" data-size="line"> Unleash the Power of Filecoin’s Reference Implementation
 

--- a/storage-providers/filecoin-deals/auxiliary-services.md
+++ b/storage-providers/filecoin-deals/auxiliary-services.md
@@ -9,7 +9,7 @@ description: >-
 
 ## Saturn
 
-One of the additional services is participation in Saturn retrieval markets. [Saturn](https://saturn.tech) is a Web3 CDN (“content delivery network”), and will [launch in stages in 2023](https://saturn.tech/#roadmap). Saturn aims to be the biggest Web3 CDN, and biggest CDN overall with the introduction of Saturn, data stored on Filecoin is no longer limited to archive or cold storage, but can also be cached into a CDN layer for fast retrieval. Data that needs to be available quickly can then be stored on Filecoin and retrieved through Saturn. Saturn comes with 2 layers of caching, L1 and L2. L1 nodes typically run in data centers, require high availability and 10 GBs minimum connectivity. The L1 Saturn provider earns FIL through caching and serving data to clients. L2 nodes can be run via an app on desktop hardware.
+One of the additional services is participation in Saturn retrieval markets. [Saturn](https://github.com/filecoin-saturn) is a Web3 CDN (“content delivery network”). Saturn aims to be the biggest Web3 CDN, and biggest CDN overall with the introduction of Saturn, data stored on Filecoin is no longer limited to archive or cold storage, but can also be cached into a CDN layer for fast retrieval. Data that needs to be available quickly can then be stored on Filecoin and retrieved through Saturn. Saturn comes with 2 layers of caching, L1 and L2. L1 nodes typically run in data centers, require high availability and 10 GBs minimum connectivity. The L1 Saturn provider earns FIL through caching and serving data to clients. L2 nodes can be run via an app on desktop hardware.
 
 ## FVM
 

--- a/storage-providers/filecoin-deals/auxiliary-services.md
+++ b/storage-providers/filecoin-deals/auxiliary-services.md
@@ -9,7 +9,7 @@ description: >-
 
 ## Saturn
 
-One of the additional services is participation in Saturn retrieval markets. [Saturn](https://github.com/filecoin-saturn) is a Web3 CDN (“content delivery network”). Saturn aims to be the biggest Web3 CDN, and biggest CDN overall with the introduction of Saturn, data stored on Filecoin is no longer limited to archive or cold storage, but can also be cached into a CDN layer for fast retrieval. Data that needs to be available quickly can then be stored on Filecoin and retrieved through Saturn. Saturn comes with 2 layers of caching, L1 and L2. L1 nodes typically run in data centers, require high availability and 10 GBs minimum connectivity. The L1 Saturn provider earns FIL through caching and serving data to clients. L2 nodes can be run via an app on desktop hardware.
+One of the additional services is participation in Saturn retrieval markets. [Saturn](https://github.com/filecoin-saturn) is a Web3 CDN (“content delivery network”). Saturn aims to be the biggest Web3 CDN, and biggest CDN overall with the introduction of Saturn, data stored on Filecoin is no longer limited to archive or cold storage, but can also be cached into a CDN layer for fast retrieval. Data that needs to be available quickly can then be stored on Filecoin and retrieved through Saturn. Saturn comes with 2 layers of caching, L1 and L2. L1 nodes typically run in data centers, require high availability and 10 Gbps minimum connectivity. The L1 Saturn provider earns FIL through caching and serving data to clients. L2 nodes can be run via an app on desktop hardware.
 
 ## FVM
 

--- a/storage-providers/filecoin-deals/return-on-investment.md
+++ b/storage-providers/filecoin-deals/return-on-investment.md
@@ -20,7 +20,7 @@ Calculating the Return-on-Investment (ROI) of your storage provider business is 
 
 **Overall**, calculating the ROI of a storage provider business is complex and requires a thorough understanding of the costs and income streams involved. The storage provider Forecast Calculator can assist in determining the ROI by accounting for various factors such as hardware costs, token price, and expected growth of the network.
 
-Calculating the ROI of your storage provider business is important. Check out the [Storage Provider Forecast Calculator](https://calc.filecoin.eu/) for more details.
+Calculating the ROI of your storage provider business is important. The sections below cover the main variables to consider when modeling storage provider costs and returns.
 
 For more information and context see the following video:
 

--- a/storage-providers/filecoin-deals/return-on-investment.md
+++ b/storage-providers/filecoin-deals/return-on-investment.md
@@ -18,7 +18,7 @@ Calculating the Return-on-Investment (ROI) of your storage provider business is 
 
 **Finally**, the forecasted growth of the network and the demand for storage will also impact the ROI calculation. If the network and demand for storage grow rapidly, the ROI may increase. However, if the growth is slower than anticipated, the ROI may decrease.
 
-**Overall**, calculating the ROI of a storage provider business is complex and requires a thorough understanding of the costs and income streams involved. The storage provider Forecast Calculator can assist in determining the ROI by accounting for various factors such as hardware costs, token price, and expected growth of the network.
+**Overall**, calculating the ROI of a storage provider business is complex and requires a thorough understanding of the costs and income streams involved. A forecasting model or spreadsheet can help determine ROI by accounting for factors such as hardware costs, token price, and expected growth of the network.
 
 Calculating the ROI of your storage provider business is important. The sections below cover the main variables to consider when modeling storage provider costs and returns.
 

--- a/storage-providers/filecoin-deals/verified-deals.md
+++ b/storage-providers/filecoin-deals/verified-deals.md
@@ -30,7 +30,7 @@ As a storage provider, you play a crucial role in the ecosystem. Unlike miners i
 
 Acquiring data copies requires systems and infrastructure capable of ingesting large volumes of data, sometimes up to a PiB. This necessitates significant internet bandwidth, with a minimum of 10 GB. For instance, transferring 1 PiB of data takes approximately 240 hours on a 10 GB connection. However, many large storage providers use up to 100 GB internet connections. \`\`\`
 
-Data preparation, which involves separating files and folders in CAR files, is time-consuming and requires expertise. You can delegate this task to a Data Preparer for a fee or assume the role yourself. Tools like [Singularity](https://singularity.storage/) simplify this process.
+Data preparation, which involves separating files and folders in CAR files, is time-consuming and requires expertise. You can delegate this task to a Data Preparer for a fee or assume the role yourself. Tools like [Singularity](https://data-programs.gitbook.io/singularity) simplify this process.
 
 Once the data is sealed and you are proving your copies on-chain (i.e. on the blockchain), you will need to offer retrievals to your customer as well. This obviously requires network bandwidth once more, so you may need to charge for retrievals accordingly.
 

--- a/storage-providers/filecoin-deals/verified-deals.md
+++ b/storage-providers/filecoin-deals/verified-deals.md
@@ -28,7 +28,7 @@ As a storage provider, you play a crucial role in the ecosystem. Unlike miners i
 * Networking.
 * Relationship building.
 
-Acquiring data copies requires systems and infrastructure capable of ingesting large volumes of data, sometimes up to a PiB. This necessitates significant internet bandwidth, with a minimum of 10 GB. For instance, transferring 1 PiB of data takes approximately 240 hours on a 10 GB connection. However, many large storage providers use up to 100 GB internet connections. \`\`\`
+Acquiring data copies requires systems and infrastructure capable of ingesting large volumes of data, sometimes up to a PiB. This necessitates significant internet bandwidth, with a minimum of 10 Gbps. For instance, transferring 1 PiB of data takes approximately 240 hours on a 10 Gbps connection. However, many large storage providers use up to 100 Gbps internet connections.
 
 Data preparation, which involves separating files and folders in CAR files, is time-consuming and requires expertise. You can delegate this task to a Data Preparer for a fee or assume the role yourself. Tools like [Singularity](https://data-programs.gitbook.io/singularity) simplify this process.
 

--- a/storage-providers/infrastructure/backup-and-disaster-recovery.md
+++ b/storage-providers/infrastructure/backup-and-disaster-recovery.md
@@ -44,7 +44,7 @@ Both storage providers and data owners (customers) should look at RPO and RTO op
 RTO for data owners is a matter of how fast the storage provider(s) can provide you the data.
 
 * Do your storage providers offer “fast retrieval” of the data through unsealed copies? If not, the unsealing process (typically multiple hours) must be calculated into the RTO.
-* Do your storage providers offer retrieval through [Saturn, (the Web3 CDN)](https://saturn.tech) for ultra-fast retrieval?
+* Do your storage providers offer retrieval through [Saturn, (the Web3 CDN)](https://github.com/filecoin-saturn) for ultra-fast retrieval?
 * Do your storage providers pin your data on IPFS, in addition to storing it on Filecoin?
 
 RPO for data owners is less of a concern, especially once the data is sealed. The Filecoin blockchain will enforce availability and durability of the data being stored, once it is sealed. It is therefore important, as a data owner, to know how fast your storage provider can prove the data on-chain.

--- a/storage-providers/infrastructure/network.md
+++ b/storage-providers/infrastructure/network.md
@@ -9,7 +9,7 @@ description: >-
 
 ## Internet bandwidth
 
-The amount of internet bandwidth required for a network largely depends on the size of the organization and customer expectations. A bandwidth between 1 Gbps and 10 Gbps is generally sufficient for most organizations, but the specific requirements should be determined based on the expected traffic. A minimum bandwidth of 10 Gbps is recommended for setups that include a [Saturn](https://saturn.tech) node. Saturn requires a high-speed connection to handle large amounts of data.
+The amount of internet bandwidth required for a network largely depends on the size of the organization and customer expectations. A bandwidth between 1 Gbps and 10 Gbps is generally sufficient for most organizations, but the specific requirements should be determined based on the expected traffic. A minimum bandwidth of 10 Gbps is recommended for setups that include a [Saturn](https://github.com/filecoin-saturn) node. Saturn requires a high-speed connection to handle large amounts of data.
 
 ## LAN bandwidth
 


### PR DESCRIPTION
## Summary

- Replace stale external links that currently fail the upstream `Check external links` workflow.
- Update Filecoin Slack, grants, events, blog, storage onramp, Saturn, FIDL, Lighthouse, 0x, and related docs references to current working destinations.
- Remove dead article/resource links where I could not verify a trustworthy current replacement.

## Validation

- `git diff --check`
- Clean-source lychee run with the workflow args: `--accept 200,429,403 --timeout 60 --retry-wait-time 15 --max-retries 10 '**/*.md'`
- Result: `1785 Total`, `1763 OK`, `0 Errors`, `22 Excluded`
 