### PR TITLE
docs(pdp): remove alpha feature warnings from PDP section

### DIFF
--- a/storage-providers/pdp/README.md
+++ b/storage-providers/pdp/README.md
@@ -13,11 +13,3 @@ layout:
 ---
 
 # PDP
-
-{% hint style="danger" %}
-**ALPHA FEATURE - UNDER DEVELOPMENT**
-
-This documentation covers the PDP (Proof of Data Possession) feature, which is currently in alpha and under active development. This tool is intended for testing and experimental use only.
-
-For production use and submitting real deals with live PDP Storage Providers, please use the [Synapse SDK](https://github.com/FilOzone/synapse-sdk).
-{% endhint %}

--- a/storage-providers/pdp/install-and-run-pdp.md
+++ b/storage-providers/pdp/install-and-run-pdp.md
@@ -6,14 +6,6 @@ description: >-
 
 # Install & Run PDP
 
-{% hint style="danger" %}
-**ALPHA FEATURE - UNDER DEVELOPMENT**
-
-This documentation covers the PDP (Proof of Data Possession) feature, which is currently in alpha and under active development. This tool is intended for testing and experimental use only.
-
-For production use and submitting real deals with live PDP Storage Providers, please use the [Synapse SDK](https://github.com/FilOzone/synapse-sdk).
-{% endhint %}
-
 ## 🚀 Prerequisites
 
 {% hint style="warning" %}


### PR DESCRIPTION
Remove the "ALPHA FEATURE - UNDER DEVELOPMENT" danger hint blocks from the PDP landing page and the Install & Run PDP guide, including the Synapse SDK production pointer they contained.