### PR TITLE
docs: clarify provider and retrieval implementation paths

### DIFF
--- a/getting-started/how-retrieval-works/serving-retrievals.md
+++ b/getting-started/how-retrieval-works/serving-retrievals.md
@@ -33,6 +33,18 @@ The client then attempts to retrieve the data from the SP over Bitswap, Graphsyn
 
 Once the client has received the last chunk of data, the connection is closed.
 
+### Implementation paths
+
+Different retrieval workflows use different tools:
+
+| Workflow | Maintained path |
+| --- | --- |
+| Serving retrievals as a storage provider | Use [Boost](https://boost.filecoin.io/) to serve retrievals. Boost supports Graphsync retrievals by default, and storage providers can run [`booster-http`](https://boost.filecoin.io/http-retrieval) for HTTP retrievals when configured. |
+| Retrieving data as a client | Use [Lassie](https://github.com/filecoin-project/lassie) to fetch content from Filecoin and IPFS using the best available retrieval path. |
+| Retrieving application data through Filecoin Onchain Cloud | Use the [Synapse SDK](https://docs.filecoin.cloud/getting-started/) for Filecoin Onchain Cloud storage and download flows. For app-facing fast delivery, [Filecoin Beam](https://docs.filbeam.com/) is available as a Filecoin Onchain Cloud delivery add-on for supported data. |
+
+Saturn content is preserved as [legacy reference material](../../reference/general/legacy-content.md) and is not the recommended path for new retrieval integrations.
+
 
 
 [Was this page helpful?](https://airtable.com/apppq4inOe4gmSSlk/pagoZHC2i1iqgphgl/form?prefill\_Page+URL=https://docs.filecoin.io/getting-started/how-retrieval-works/serving-retrievals)

--- a/getting-started/how-retrieval-works/serving-retrievals.md
+++ b/getting-started/how-retrieval-works/serving-retrievals.md
@@ -39,11 +39,10 @@ Different retrieval workflows use different tools:
 
 | Workflow | Maintained path |
 | --- | --- |
-| Serving retrievals as a storage provider | Use [Boost](https://boost.filecoin.io/) to serve retrievals. Boost supports Graphsync retrievals by default, and storage providers can run [`booster-http`](https://boost.filecoin.io/http-retrieval) for HTTP retrievals when configured. |
+| Serving PDP retrievals as a storage provider | Use [Curio](https://curiostorage.org/) for PDP retrievals. |
+| Serving PoRep retrievals as a storage provider | Use [Boost](https://boost.filecoin.io/) to serve retrievals. Boost supports Graphsync retrievals by default, and storage providers can run [`booster-http`](https://boost.filecoin.io/http-retrieval) for HTTP retrievals when configured. |
 | Retrieving data as a client | Use [Lassie](https://github.com/filecoin-project/lassie) to fetch content from Filecoin and IPFS using the best available retrieval path. |
-| Retrieving application data through Filecoin Onchain Cloud | Use the [Synapse SDK](https://docs.filecoin.cloud/getting-started/) for Filecoin Onchain Cloud storage and download flows. For app-facing fast delivery, [Filecoin Beam](https://docs.filbeam.com/) is available as a Filecoin Onchain Cloud delivery add-on for supported data. |
-
-Saturn content is preserved as [legacy reference material](../../reference/general/legacy-content.md) and is not the recommended path for new retrieval integrations.
+| Retrieving application data with Filecoin Onchain Cloud | See the [Filecoin Onchain Cloud documentation](https://docs.filecoin.cloud/getting-started/) for maintained Synapse SDK storage and download flows. |
 
 
 

--- a/getting-started/how-retrieval-works/serving-retrievals.md
+++ b/getting-started/how-retrieval-works/serving-retrievals.md
@@ -42,7 +42,7 @@ Different retrieval workflows use different tools:
 | Serving PDP retrievals as a storage provider | Use [Curio](https://curiostorage.org/) for PDP retrievals. |
 | Serving PoRep retrievals as a storage provider | Use [Boost](https://boost.filecoin.io/) to serve retrievals. Boost supports Graphsync retrievals by default, and storage providers can run [`booster-http`](https://boost.filecoin.io/http-retrieval) for HTTP retrievals when configured. |
 | Retrieving data as a client | Use [Lassie](https://github.com/filecoin-project/lassie) to fetch content from Filecoin and IPFS using the best available retrieval path. |
-| Retrieving application data with Filecoin Onchain Cloud | See the [Filecoin Onchain Cloud documentation](https://docs.filecoin.cloud/getting-started/) for maintained Synapse SDK storage and download flows. |
+| Retrieving application data with Filecoin Onchain Cloud | See the [Filecoin Onchain Cloud retrieval docs](https://docs.filecoin.cloud/core-concepts/retrieval/) for maintained Synapse SDK retrieval flows. |
 
 
 

--- a/storage-providers/getting-started.md
+++ b/storage-providers/getting-started.md
@@ -20,10 +20,10 @@ Follow these steps to begin your storage provider journey:
 4. Build the right infrastructure
 5. Get to know the ecosystem
 6. Understand ROI and collateral
-7. Get started with Lotus
+7. Choose your provider software stack
 8. Set up a local development environment
 9. Become a storage provider
-10. Supercharge your mainnet experience with Boost
+10. Configure deal-making and retrieval services
 11. Explore verified deals and ecosystem tools
 
 ## Understand Filecoin economics
@@ -109,9 +109,19 @@ One of the enriching elements of the Filecoin ecosystem lies in its vibrant comm
 
 To run a successful storage provider business, it is crucial to understand the concept of Return on Investment (ROI) and the significance of collateral. By planning ahead and considering various factors, such as CAPEX, OPEX, network variables, and collateral requirements, you can make informed decisions that impact your business's profitability and desired capacity.
 
-## Get started with Lotus <a href="#get-started-with-lotus" id="get-started-with-lotus"></a>
+## Choose your provider software stack <a href="#choose-your-provider-software-stack" id="choose-your-provider-software-stack"></a>
 
-Lotus is the leading reference implementation of the Filecoin protocol and the most widely used software stack for interacting with the blockchain and operating a storage provider setup. Understanding Lotus is fundamental to navigating the Filecoin network and building a reliable storage operation.
+Storage providers usually run several pieces of software together. Start by understanding which component handles each part of the operation:
+
+| Component | Role |
+| --- | --- |
+| [Curio](https://curiostorage.org/) | Modern storage-provider stack for running provider operations, including sealing and proving workflows. |
+| [Lotus](https://lotus.filecoin.io) | Reference Filecoin implementation for chain sync, node operations, miner actor interactions, and client tooling. |
+| [Boost](https://boost.filecoin.io) | Deal-making and retrieval software for accepting storage deals and serving retrievals, including HTTP retrievals when configured. |
+
+For new storage-provider planning, treat Curio as the provider operations stack, Lotus as the underlying Filecoin node and chain tooling, and Boost as the storage-deal and retrieval layer. Use each project's maintained documentation for installation and production configuration.
+
+[Curio documentation ->](https://docs.curiostorage.org/)
 
 [Lotus documentation ->](https://lotus.filecoin.io)
 
@@ -127,9 +137,9 @@ Once ready, determine your starting capacity and architect a solution to accommo
 
 [Reference architectures ->](./infrastructure/reference-architectures.md)
 
-## Supercharge your mainnet experience with Boost <a href="#supercharge-your-mainnet-experience-with-boost" id="supercharge-your-mainnet-experience-with-boost"></a>
+## Configure deal-making and retrieval services <a href="#configure-deal-making-and-retrieval-services" id="configure-deal-making-and-retrieval-services"></a>
 
-As you step into the mainnet, Boost is the software designed to help you secure storage deals and offer efficient data retrieval services to data owners. Deploying Boost unlocks your ability to participate in deal-making and serve clients across the Filecoin network.
+As you step into the mainnet, Boost helps you accept storage deals and offer data retrieval services to data owners. Deploying Boost unlocks your ability to participate in deal-making and serve clients across the Filecoin network.
 
 [Boost documentation ->](https://boost.filecoin.io)
 

--- a/storage-providers/getting-started.md
+++ b/storage-providers/getting-started.md
@@ -23,7 +23,7 @@ Follow these steps to begin your storage provider journey:
 7. Choose your provider software stack
 8. Set up a local development environment
 9. Become a storage provider
-10. Configure deal-making and retrieval services
+10. Configure PoRep deal-making and retrieval services
 11. Explore verified deals and ecosystem tools
 
 ## Understand Filecoin economics
@@ -109,17 +109,17 @@ One of the enriching elements of the Filecoin ecosystem lies in its vibrant comm
 
 To run a successful storage provider business, it is crucial to understand the concept of Return on Investment (ROI) and the significance of collateral. By planning ahead and considering various factors, such as CAPEX, OPEX, network variables, and collateral requirements, you can make informed decisions that impact your business's profitability and desired capacity.
 
-## Choose your provider software stack <a href="#choose-your-provider-software-stack" id="choose-your-provider-software-stack"></a>
+## Choose your provider software stack
 
 Storage providers usually run several pieces of software together. Start by understanding which component handles each part of the operation:
 
 | Component | Role |
 | --- | --- |
-| [Curio](https://curiostorage.org/) | Modern storage-provider stack for running provider operations, including sealing and proving workflows. |
+| [Curio](https://curiostorage.org/) | Modern storage-provider stack for running provider operations, including PDP storage, proving, and retrieval, and PoRep sealing and proving workflows. |
 | [Lotus](https://lotus.filecoin.io) | Reference Filecoin implementation for chain sync, node operations, miner actor interactions, and client tooling. |
-| [Boost](https://boost.filecoin.io) | Deal-making and retrieval software for accepting storage deals and serving retrievals, including HTTP retrievals when configured. |
+| [Boost](https://boost.filecoin.io) | Deal-making and retrieval software for accepting PoRep storage deals and serving retrievals, including HTTP retrievals when configured. |
 
-For new storage-provider planning, treat Curio as the provider operations stack, Lotus as the underlying Filecoin node and chain tooling, and Boost as the storage-deal and retrieval layer. Use each project's maintained documentation for installation and production configuration.
+For new storage-provider planning, treat Curio as the provider operations stack, Lotus as the underlying Filecoin node and chain tooling, and optionally Boost as the PoRep storage-deal and retrieval layer. Use each project's maintained documentation for installation and production configuration.
 
 [Curio documentation ->](https://docs.curiostorage.org/)
 
@@ -137,9 +137,11 @@ Once ready, determine your starting capacity and architect a solution to accommo
 
 [Reference architectures ->](./infrastructure/reference-architectures.md)
 
-## Configure deal-making and retrieval services <a href="#configure-deal-making-and-retrieval-services" id="configure-deal-making-and-retrieval-services"></a>
+## Configure PoRep deal-making and retrieval services
 
-As you step into the mainnet, Boost helps you accept storage deals and offer data retrieval services to data owners. Deploying Boost unlocks your ability to participate in deal-making and serve clients across the Filecoin network.
+As you step into the mainnet, Boost helps you accept PoRep storage deals and offer data retrieval services to data owners. Deploying Boost unlocks your ability to participate in PoRep deal-making and serve clients across the Filecoin network.
+
+Boost is not used for PDP deals and retrieval.
 
 [Boost documentation ->](https://boost.filecoin.io)
 


### PR DESCRIPTION
## Summary

Follow-up to #2457.

- Add Curio to the Provide Storage getting-started path alongside Lotus and Boost, with each component's role clarified.
- Rename the Boost step to focus on PoRep deal-making and retrieval services.
- Add retrieval implementation paths for PDP providers, PoRep providers, clients, and Filecoin Onchain Cloud application flows.
- Remove Saturn from the recommended retrieval path guidance.

## Review links

- [Provide Storage: choose your provider software stack](https://docs.filecoin.io/~/revisions/3tJClOPcjzXGr2KlfYIR/provide-storage/getting-started#choose-your-provider-software-stack) - Review the Curio/Lotus/Boost role table and confirm this matches current storage-provider guidance.
- [Provide Storage: configure PoRep deal-making and retrieval services](https://docs.filecoin.io/~/revisions/3tJClOPcjzXGr2KlfYIR/provide-storage/getting-started#configure-porep-deal-making-and-retrieval-services) - Review the Boost section and confirm the PoRep deal-making/retrieval framing is accurate.
- [Serving retrievals: implementation paths](https://docs.filecoin.io/~/revisions/3tJClOPcjzXGr2KlfYIR/getting-started/how-retrieval-works/serving-retrievals#implementation-paths) - Review the retrieval path table for PDP providers, PoRep providers, Lassie clients, and FOC application flows.

## Validation

- `npm run build`
- Targeted link probes for newly added or edited external links: Curio, Curio docs, Lotus docs, Boost docs, Boost HTTP retrieval docs, Lassie repo, and FOC retrieval docs all returned `200`.
