### PR TITLE
Refresh retrieval overview

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -110,7 +110,7 @@ redirects:
   basics/what-is-filecoin/networks: getting-started/what-is-filecoin/networks.md
   basics/what-is-filecoin/overview: getting-started/what-is-filecoin/README.md
   basics/what-is-filecoin/programming-on-filecoin: getting-started/what-is-filecoin/programming-on-filecoin.md
-  basics/what-is-filecoin/retrieval-market: getting-started/what-is-filecoin/retrieval-market.md
+  basics/what-is-filecoin/retrieval-market: getting-started/what-is-filecoin/retrieval.md
   basics/what-is-filecoin/storage-market: getting-started/what-is-filecoin/storage-market.md
   basics/what-is-filecoin/storage-model: getting-started/what-is-filecoin/storage-model.md
   build: core-concepts/filecoin-virtual-machine/README.md
@@ -329,6 +329,7 @@ redirects:
   get-started/lotus/tips-running-in-china: storage-providers/getting-started.md
   get-started/lotus/troubleshooting: storage-providers/nodes/implementations/lotus.md
   get-started/overview: getting-started/what-is-filecoin/README.md
+  getting-started/what-is-filecoin/retrieval-market: getting-started/what-is-filecoin/retrieval.md
   get-started/overview/get-started: core-concepts/filecoin-virtual-machine/README.md
   get-started/resources: storage-providers/getting-started.md
   get-started/store-and-retrieve: getting-started/what-is-filecoin/storage-market.md
@@ -363,7 +364,7 @@ redirects:
   intro/intro-to-filecoin/crypto-economics: getting-started/what-is-filecoin/crypto-economics.md
   intro/intro-to-filecoin/network: getting-started/what-is-filecoin/networks.md
   intro/intro-to-filecoin/programming-on-filecoin: getting-started/what-is-filecoin/programming-on-filecoin.md
-  intro/intro-to-filecoin/retrieval-market: getting-started/what-is-filecoin/retrieval-market.md
+  intro/intro-to-filecoin/retrieval-market: getting-started/what-is-filecoin/retrieval.md
   intro/intro-to-filecoin/storage-market: getting-started/what-is-filecoin/storage-market.md
   intro/intro-to-filecoin/storage-model: getting-started/what-is-filecoin/storage-model.md
   intro/intro-to-filecoin/what-is-filecoin: getting-started/what-is-filecoin/README.md

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -9,7 +9,7 @@
   * [Blockchain](getting-started/what-is-filecoin/blockchain.md)
   * [Storage model](getting-started/what-is-filecoin/storage-model.md)
   * [Storage market](getting-started/what-is-filecoin/storage-market.md)
-  * [Retrieval](getting-started/what-is-filecoin/retrieval-market.md)
+  * [Retrieval](getting-started/what-is-filecoin/retrieval.md)
   * [Programming on Filecoin](getting-started/what-is-filecoin/programming-on-filecoin.md)
   * [Networks](getting-started/what-is-filecoin/networks.md)
 * [How storage works](getting-started/how-storage-works/README.md)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -9,7 +9,7 @@
   * [Blockchain](getting-started/what-is-filecoin/blockchain.md)
   * [Storage model](getting-started/what-is-filecoin/storage-model.md)
   * [Storage market](getting-started/what-is-filecoin/storage-market.md)
-  * [Retrieval market](getting-started/what-is-filecoin/retrieval-market.md)
+  * [Retrieval](getting-started/what-is-filecoin/retrieval-market.md)
   * [Programming on Filecoin](getting-started/what-is-filecoin/programming-on-filecoin.md)
   * [Networks](getting-started/what-is-filecoin/networks.md)
 * [How storage works](getting-started/how-storage-works/README.md)

--- a/getting-started/how-retrieval-works/README.md
+++ b/getting-started/how-retrieval-works/README.md
@@ -7,7 +7,7 @@ description: >-
 
 This section covers the implementation details behind Filecoin retrieval: finding providers, choosing a retrieval path, and fetching CID-addressed content.
 
-For a high-level overview of managed and direct retrieval paths, see [Retrieval](../what-is-filecoin/retrieval-market.md).
+For a high-level overview of managed and direct retrieval paths, see [Retrieval](../what-is-filecoin/retrieval.md).
 
 ## Table of contents
 

--- a/getting-started/how-retrieval-works/README.md
+++ b/getting-started/how-retrieval-works/README.md
@@ -5,11 +5,13 @@ description: >-
 
 # How retrieval works
 
-This section covers how Filecoin retrieval works, from finding providers to fetching content.
+This section covers the implementation details behind Filecoin retrieval: finding providers, choosing a retrieval path, and fetching CID-addressed content.
+
+For a high-level overview of managed and direct retrieval paths, see [Retrieval](../what-is-filecoin/retrieval-market.md).
 
 ## Table of contents
 
-* [Basic retrieval](basic-retrieval.md) — retrieve data with a client like Lassie
-* [Serving retrievals](serving-retrievals.md) — how retrieval deals work and how the indexer fits in
+* [Basic retrieval](basic-retrieval.md) - fetch CID-addressed data with Lassie and work with CAR output
+* [Serving retrievals](serving-retrievals.md) - understand provider advertisements, IPNI, and storage-provider retrieval endpoints
 
 [Was this page helpful?](https://airtable.com/apppq4inOe4gmSSlk/pagoZHC2i1iqgphgl/form?prefill\_Page+URL=https://docs.filecoin.io/getting-started/how-retrieval-works)

--- a/getting-started/how-retrieval-works/basic-retrieval.md
+++ b/getting-started/how-retrieval-works/basic-retrieval.md
@@ -14,9 +14,9 @@ Lassie is a simple retrieval client for IPFS and Filecoin. It finds and fetches 
 lassie fetch <CID>
 ```
 
-Lassie also provides an HTTP interface for retrieving IPLD data from IPFS and Filecoin peers. Developers can use this interface directly in their applications to retrieve the data.
+Lassie also provides an HTTP interface for retrieving IPLD data from IPFS and Filecoin peers. Developers can use this interface directly in their applications to retrieve data by CID.
 
-Lassie fetches content in content-addressed archive (CAR) form, so in most cases, you will need additional tooling to deal with CAR files. Lassie can also be used as a library to fetch data from Filecoin from within your application. Due to the diversity of data transport protocols in the IPFS ecosystem, Lassie is able to use the Graphsync or Bitswap protocols, depending on how the requested data is available to be fetched.
+Lassie fetches content in content-addressed archive (CAR) form, so in most cases, you will need additional tooling to work with CAR files. Lassie can also be used as a Go library. It retrieves CID-addressed IPLD data over the available protocols advertised for that content, including HTTP, Bitswap, or Graphsync depending on provider support. Use provider or service `/piece` endpoints when you need to retrieve a whole PieceCID.
 
 ![Lassie Architecture](../../.gitbook/assets/basics-how-retrieval-works-basic-retrieval-lassie-library.webp)
 

--- a/getting-started/how-retrieval-works/serving-retrievals.md
+++ b/getting-started/how-retrieval-works/serving-retrievals.md
@@ -9,9 +9,9 @@ description: >-
 
 ### The indexer
 
-When a storage deal is originally made, the client can opt to make the data publicly discoverable. If this is the case, the storage provider must publish an advertisement of the storage deal to the Interplanetary Network Indexer (IPNI). IPNI maps a CID to a storage provider (SP). This mapping allows clients to query the IPNI to discover where content is on Filecoin.
+When data should be publicly discoverable, the storage provider publishes an advertisement to the InterPlanetary Network Indexer (IPNI). IPNI maps content identifiers to storage providers and retrieval metadata so clients can discover where content is available.
 
-The IPNI also tracks which data transfer protocols you can use to retrieve specific CIDs. Currently, Filecoin SPs have the ability to serve retrievals over Graphsync, Bitswap, and HTTP. This is dependent on the SP setup.
+IPNI can also include the retrieval protocols or endpoints a provider advertises for specific CIDs. Filecoin storage providers may serve retrievals over HTTP, Bitswap, Graphsync, or service-specific endpoints depending on their software and configuration.
 
 ### Retrieval process
 
@@ -19,15 +19,15 @@ If a client wants to retrieve publicly available data from the Filecoin network,
 
 #### Query the IPNI
 
-Before the client can submit a retrieval deal to a storage provider, they first need to find which providers hold the data. To do this, the client sends a query to the Interplanetary Network Indexer.
+Before the client can retrieve from a storage provider, they first need to find which providers hold the data. To do this, the client sends a query to the InterPlanetary Network Indexer.
 
 #### Select a provider
 
-Assuming the IPNI returns more than one storage provider, the client can select which provider they’d like to deal with. Here, they will also get additional details (if needed) based on the retrieval protocol they want to retrieve the content over.
+Assuming IPNI returns more than one storage provider, the client can select which provider to retrieve from. Here, they will also get additional details based on the retrieval path they want to use.
 
 #### Initiate retrieval
 
-The client then attempts to retrieve the data from the SP over Bitswap, Graphsync, or HTTP. Note that currently, clients can only get full-piece retrievals using HTTP.
+The client then retrieves the data from the storage provider over one of the advertised paths. HTTP retrieval is the common path for whole-piece `/piece/{pieceCid}` retrieval. Providers that index and advertise IPFS CIDs can also expose `/ipfs/{cid}` style retrieval.
 
 #### Finalize the retrieval
 
@@ -41,9 +41,7 @@ Different retrieval workflows use different tools:
 | --- | --- |
 | Serving PDP retrievals as a storage provider | Use [Curio](https://curiostorage.org/) for PDP retrievals. |
 | Serving PoRep retrievals as a storage provider | Use [Boost](https://boost.filecoin.io/) to serve retrievals. Boost supports Graphsync retrievals by default, and storage providers can run [`booster-http`](https://boost.filecoin.io/http-retrieval) for HTTP retrievals when configured. |
-| Retrieving data as a client | Use [Lassie](https://github.com/filecoin-project/lassie) to fetch content from Filecoin and IPFS using the best available retrieval path. |
+| Retrieving data as a client | Use [Lassie](https://github.com/filecoin-project/lassie) to fetch CID-addressed content from Filecoin and IPFS using the best available retrieval path. For whole-piece retrieval, use provider or service `/piece` endpoints. |
 | Retrieving application data with Filecoin Onchain Cloud | See the [Filecoin Onchain Cloud retrieval docs](https://docs.filecoin.cloud/core-concepts/retrieval/) for maintained Synapse SDK retrieval flows. |
-
-
 
 [Was this page helpful?](https://airtable.com/apppq4inOe4gmSSlk/pagoZHC2i1iqgphgl/form?prefill\_Page+URL=https://docs.filecoin.io/getting-started/how-retrieval-works/serving-retrievals)

--- a/getting-started/what-is-filecoin/retrieval-market.md
+++ b/getting-started/what-is-filecoin/retrieval-market.md
@@ -1,22 +1,93 @@
 ---
 description: >-
-  The retrieval market facilitates the negotiation of retrieval deals for serving stored data to clients in exchange for FIL.
+  Retrieval is how users fetch content from Filecoin storage providers, IPFS,
+  and Filecoin-based storage services.
 ---
 
-# Retrieval market
+# Retrieval
 
-## Basic Retrieval from Filecoin
+Retrieval means fetching stored data back by its content identifier. In
+Filecoin, that usually starts with a CID or PieceCID and then routes to a
+storage provider, IPFS peer, gateway, or managed storage service that can serve
+the content.
 
-Currently, Filecoin nodes support direct retrieval from the storage miners who originally stored the data. Clients can send retrieval requests directly to a storage provider and pay a small amount of FIL to retrieve their data.
+Filecoin retrieval is no longer best described as a single retrieval market. The
+right path depends on how the data was stored, whether it was advertised for
+public discovery, and whether you want to use a managed API or retrieve directly
+from the network.
 
-To request data retrieval, clients need to provide the following information to the storage provider:
+## Common retrieval paths
 
-- **Storage Provider ID**: The ID of the storage provider where the data is stored.
-- **Payload CID**: Also known as Data CID.
-- **Address**: The address initially used to create the storage deal.
+### Retrieve by CID with Lassie
 
-## Hot Retrieval from IPFS
+[Lassie](https://github.com/filecoin-project/lassie) is a retrieval client for
+IPFS and Filecoin. It can find providers for a CID and fetch the content over
+the available retrieval protocols.
 
-Since most Filecoin nodes are also IPFS nodes, standard practice has been for Filecoin storage providers to also make available a hot copy of any given stored file through IPFS.  Since the algorithm that generates a content address (CID) is the same for both Filecoin and IPFS, the client can request the CID of a file they stored on Filecoin and retrieve it from IPFS, if there is an IPFS node that is able and willing to serve the file. 
+Use this path when you have a CID and want a network-native way to fetch the
+data:
+
+```shell
+lassie fetch <CID>
+```
+
+See [Basic retrieval](../how-retrieval-works/basic-retrieval.md) for
+installation and CLI examples.
+
+### Retrieve public data through IPNI and provider protocols
+
+When data is made publicly discoverable, storage providers can advertise it to
+the [InterPlanetary Network Indexer](https://cid.contact/). IPNI maps CIDs to
+providers and the transfer protocols they support. Clients can then retrieve
+from a provider over protocols such as Bitswap, Graphsync, or HTTP, depending on
+how the provider is configured.
+
+See [Serving retrievals](../how-retrieval-works/serving-retrievals.md) for the
+provider discovery and retrieval flow.
+
+### Retrieve through IPFS
+
+Filecoin and IPFS both use content addressing, so Filecoin-stored content can
+often be retrieved through IPFS paths when a provider, gateway, or peer is
+serving the CID. This is useful for IPFS-native applications and for content
+that should be broadly addressable by CID.
+
+### Retrieve from Filecoin Onchain Cloud
+
+[Filecoin Onchain Cloud retrieval](https://docs.filecoin.cloud/core-concepts/retrieval/)
+provides managed retrieval paths for data stored through Filecoin Onchain Cloud.
+It supports direct storage-provider HTTP retrieval, Filecoin Beam CDN retrieval
+for lower-latency reads, and IPFS retrieval paths for IPFS-native use cases.
+
+Use this path when your application stores data through Filecoin Onchain Cloud or
+the Synapse SDK and wants managed retrieval, payment, and service-provider
+routing.
+
+### Retrieve from Fil One
+
+[Fil One](https://docs.fil.one/) is an S3-compatible object storage service
+backed by Filecoin. If your data is stored in Fil One, retrieve it through the
+same S3-compatible tools, SDKs, or application paths you use for object storage.
+
+Use this path when you want Filecoin-backed storage and retrieval behind an
+S3-compatible API rather than direct CID-level retrieval.
+
+### Retrieve directly from a storage provider
+
+Direct provider retrieval is useful when you know which provider holds the data
+or you are working with a direct storage-provider workflow. You generally need
+the content identifier and enough deal or provider context to ask the provider
+for the stored payload.
+
+## Where to go next
+
+- [Basic retrieval](../how-retrieval-works/basic-retrieval.md) covers fetching
+  data with Lassie.
+- [Serving retrievals](../how-retrieval-works/serving-retrievals.md) explains
+  provider advertisements, IPNI, and retrieval protocols.
+- [Filecoin Onchain Cloud retrieval](https://docs.filecoin.cloud/core-concepts/retrieval/)
+  covers retrieval for data stored through Filecoin Onchain Cloud.
+- [Fil One docs](https://docs.fil.one/) cover retrieval through S3-compatible
+  object storage APIs.
 
 [Was this page helpful?](https://airtable.com/apppq4inOe4gmSSlk/pagoZHC2i1iqgphgl/form?prefill_Page+URL=https://docs.filecoin.io/getting-started/what-is-filecoin/retrieval-market)

--- a/getting-started/what-is-filecoin/retrieval-market.md
+++ b/getting-started/what-is-filecoin/retrieval-market.md
@@ -1,67 +1,23 @@
 ---
 description: >-
   Retrieval is how users fetch content from Filecoin storage providers, IPFS,
-  and Filecoin-based storage services.
+  and Filecoin-backed storage services.
 ---
 
 # Retrieval
 
-Retrieval means fetching stored data back by its content identifier. In
-Filecoin, that usually starts with a CID or PieceCID and then routes to a
-storage provider, IPFS peer, gateway, or managed storage service that can serve
-the content.
-
-Filecoin retrieval is no longer best described as a single retrieval market. The
-right path depends on how the data was stored, whether it was advertised for
-public discovery, and whether you want to use a managed API or retrieve directly
-from the network.
+Retrieval means fetching stored data back from Filecoin by CID, PieceCID, or a
+service-specific object path. Start with the storage path you used, then choose
+the matching retrieval path below.
 
 ## Common retrieval paths
 
-### Retrieve by CID with Lassie
-
-[Lassie](https://github.com/filecoin-project/lassie) is a retrieval client for
-IPFS and Filecoin. It can find providers for a CID and fetch the content over
-the available retrieval protocols.
-
-Use this path when you have a CID and want a network-native way to fetch the
-data:
-
-```shell
-lassie fetch <CID>
-```
-
-See [Basic retrieval](../how-retrieval-works/basic-retrieval.md) for
-installation and CLI examples.
-
-### Retrieve public data through IPNI and provider protocols
-
-When data is made publicly discoverable, storage providers can advertise it to
-the [InterPlanetary Network Indexer](https://cid.contact/). IPNI maps CIDs to
-providers and the transfer protocols they support. Clients can then retrieve
-from a provider over protocols such as Bitswap, Graphsync, or HTTP, depending on
-how the provider is configured.
-
-See [Serving retrievals](../how-retrieval-works/serving-retrievals.md) for the
-provider discovery and retrieval flow.
-
-### Retrieve through IPFS
-
-Filecoin and IPFS both use content addressing, so Filecoin-stored content can
-often be retrieved through IPFS paths when a provider, gateway, or peer is
-serving the CID. This is useful for IPFS-native applications and for content
-that should be broadly addressable by CID.
-
 ### Retrieve from Filecoin Onchain Cloud
 
-[Filecoin Onchain Cloud retrieval](https://docs.filecoin.cloud/core-concepts/retrieval/)
-provides managed retrieval paths for data stored through Filecoin Onchain Cloud.
-It supports direct storage-provider HTTP retrieval, Filecoin Beam CDN retrieval
-for lower-latency reads, and IPFS retrieval paths for IPFS-native use cases.
-
-Use this path when your application stores data through Filecoin Onchain Cloud or
-the Synapse SDK and wants managed retrieval, payment, and service-provider
-routing.
+Use the [Filecoin Onchain Cloud retrieval docs](https://docs.filecoin.cloud/core-concepts/retrieval/)
+when your data was stored through Filecoin Onchain Cloud or the Synapse SDK.
+That documentation covers direct storage-provider HTTP reads, Filecoin Beam CDN
+delivery, IPFS retrieval for IPFS-indexed data, and SDK download flows.
 
 ### Retrieve from Fil One
 
@@ -72,22 +28,39 @@ same S3-compatible tools, SDKs, or application paths you use for object storage.
 Use this path when you want Filecoin-backed storage and retrieval behind an
 S3-compatible API rather than direct CID-level retrieval.
 
-### Retrieve directly from a storage provider
+### Retrieve directly from Filecoin storage providers
 
-Direct provider retrieval is useful when you know which provider holds the data
-or you are working with a direct storage-provider workflow. You generally need
-the content identifier and enough deal or provider context to ask the provider
-for the stored payload.
+Use direct storage-provider retrieval when your data was stored through direct
+deal making or another provider-specific workflow and you need to fetch it from
+the providers that hold it.
+
+First determine which provider stores the content and which endpoint it exposes:
+
+- For a PieceCID, use Filecoin deal, sector, or storage-service metadata to
+  identify a provider that stores the piece, then retrieve from the provider's
+  HTTP `/piece/{pieceCid}` endpoint when available.
+- For an IPFS CID, use a content-routing system such as the
+  [InterPlanetary Network Indexer](https://cid.contact/) to find providers that
+  advertised the CID. This path depends on the storage provider advertising the
+  content.
+- Some providers expose an `/ipfs/{cid}` endpoint for IPFS-style retrieval,
+  similar to a trustless gateway.
+
+Use [Lassie](https://github.com/filecoin-project/lassie) for CID-based
+retrieval from Filecoin and IPFS. Lassie can discover providers for advertised
+CID content and fetch it with `lassie fetch <CID>`, or run as an HTTP daemon for
+`/ipfs/{cid}` requests. For whole-piece retrieval by PieceCID, use a provider or
+service path that supports `/piece`.
 
 ## Where to go next
 
-- [Basic retrieval](../how-retrieval-works/basic-retrieval.md) covers fetching
-  data with Lassie.
-- [Serving retrievals](../how-retrieval-works/serving-retrievals.md) explains
-  provider advertisements, IPNI, and retrieval protocols.
 - [Filecoin Onchain Cloud retrieval](https://docs.filecoin.cloud/core-concepts/retrieval/)
   covers retrieval for data stored through Filecoin Onchain Cloud.
 - [Fil One docs](https://docs.fil.one/) cover retrieval through S3-compatible
   object storage APIs.
+- [Basic retrieval](../how-retrieval-works/basic-retrieval.md) covers fetching
+  CID-addressed data with Lassie.
+- [Serving retrievals](../how-retrieval-works/serving-retrievals.md) explains
+  provider advertisements, IPNI, and retrieval protocols.
 
 [Was this page helpful?](https://airtable.com/apppq4inOe4gmSSlk/pagoZHC2i1iqgphgl/form?prefill_Page+URL=https://docs.filecoin.io/getting-started/what-is-filecoin/retrieval-market)

--- a/getting-started/what-is-filecoin/retrieval-market.md
+++ b/getting-started/what-is-filecoin/retrieval-market.md
@@ -1,66 +1,40 @@
 ---
 description: >-
-  Retrieval is how users fetch content from Filecoin storage providers, IPFS,
-  and Filecoin-backed storage services.
+  Retrieval is how users fetch content from Filecoin storage providers, IPFS, and Filecoin-backed storage services.
 ---
 
 # Retrieval
 
-Retrieval means fetching stored data back from Filecoin by CID, PieceCID, or a
-service-specific object path. Start with the storage path you used, then choose
-the matching retrieval path below.
+Retrieval means fetching stored data back from Filecoin. The right retrieval path depends on how the data was stored, which identifiers you have, and whether you want a managed service API or direct storage-provider retrieval.
+
+Use this page as a starting point. For implementation details, see the [How retrieval works](../how-retrieval-works/README.md) section.
 
 ## Common retrieval paths
 
 ### Retrieve from Filecoin Onchain Cloud
 
-Use the [Filecoin Onchain Cloud retrieval docs](https://docs.filecoin.cloud/core-concepts/retrieval/)
-when your data was stored through Filecoin Onchain Cloud or the Synapse SDK.
-That documentation covers direct storage-provider HTTP reads, Filecoin Beam CDN
-delivery, IPFS retrieval for IPFS-indexed data, and SDK download flows.
+Use the [Filecoin Onchain Cloud retrieval docs](https://docs.filecoin.cloud/core-concepts/retrieval/) when your data was stored through Filecoin Onchain Cloud or the Synapse SDK. Those docs cover the current FOC retrieval paths, SDK flows, and service-specific options.
 
 ### Retrieve from Fil One
 
-[Fil One](https://docs.fil.one/) is an S3-compatible object storage service
-backed by Filecoin. If your data is stored in Fil One, retrieve it through the
-same S3-compatible tools, SDKs, or application paths you use for object storage.
-
-Use this path when you want Filecoin-backed storage and retrieval behind an
-S3-compatible API rather than direct CID-level retrieval.
+[Fil One](https://docs.fil.one/) is an S3-compatible object storage service backed by Filecoin. If your data is stored in Fil One, retrieve it with the same S3-compatible tools, SDKs, or application paths you use for object storage.
 
 ### Retrieve directly from Filecoin storage providers
 
-Use direct storage-provider retrieval when your data was stored through direct
-deal making or another provider-specific workflow and you need to fetch it from
-the providers that hold it.
+Use direct storage-provider retrieval when your data was stored through direct deal making or another provider-specific workflow and you need to fetch it from the providers that hold it.
 
-First determine which provider stores the content and which endpoint it exposes:
+Direct retrieval usually starts with either a PieceCID or an IPFS CID:
 
-- For a PieceCID, use Filecoin deal, sector, or storage-service metadata to
-  identify a provider that stores the piece, then retrieve from the provider's
-  HTTP `/piece/{pieceCid}` endpoint when available.
-- For an IPFS CID, use a content-routing system such as the
-  [InterPlanetary Network Indexer](https://cid.contact/) to find providers that
-  advertised the CID. This path depends on the storage provider advertising the
-  content.
-- Some providers expose an `/ipfs/{cid}` endpoint for IPFS-style retrieval,
-  similar to a trustless gateway.
+- For a PieceCID, use Filecoin deal, sector, storage-service, or provider metadata to identify a provider that stores the piece, then retrieve from the provider's HTTP `/piece/{pieceCid}` endpoint when available.
+- For an IPFS CID, use content routing such as the [InterPlanetary Network Indexer](https://cid.contact/) to find providers that advertised the CID. Some providers expose an `/ipfs/{cid}` endpoint for IPFS-style retrieval.
 
-Use [Lassie](https://github.com/filecoin-project/lassie) for CID-based
-retrieval from Filecoin and IPFS. Lassie can discover providers for advertised
-CID content and fetch it with `lassie fetch <CID>`, or run as an HTTP daemon for
-`/ipfs/{cid}` requests. For whole-piece retrieval by PieceCID, use a provider or
-service path that supports `/piece`.
+Use [Lassie](https://github.com/filecoin-project/lassie) for CID-based retrieval from Filecoin and IPFS. Lassie can discover providers for advertised CID content and fetch it with `lassie fetch <CID>`, or run as an HTTP daemon for `/ipfs/{cid}` requests. For whole-piece retrieval by PieceCID, use a provider or service path that supports `/piece`.
 
 ## Where to go next
 
-- [Filecoin Onchain Cloud retrieval](https://docs.filecoin.cloud/core-concepts/retrieval/)
-  covers retrieval for data stored through Filecoin Onchain Cloud.
-- [Fil One docs](https://docs.fil.one/) cover retrieval through S3-compatible
-  object storage APIs.
-- [Basic retrieval](../how-retrieval-works/basic-retrieval.md) covers fetching
-  CID-addressed data with Lassie.
-- [Serving retrievals](../how-retrieval-works/serving-retrievals.md) explains
-  provider advertisements, IPNI, and retrieval protocols.
+- [Filecoin Onchain Cloud retrieval](https://docs.filecoin.cloud/core-concepts/retrieval/) covers retrieval for data stored through Filecoin Onchain Cloud.
+- [Fil One docs](https://docs.fil.one/) cover retrieval through S3-compatible object storage APIs.
+- [Basic retrieval](../how-retrieval-works/basic-retrieval.md) covers fetching CID-addressed data with Lassie.
+- [Serving retrievals](../how-retrieval-works/serving-retrievals.md) explains provider advertisements, IPNI, and retrieval protocols.
 
 [Was this page helpful?](https://airtable.com/apppq4inOe4gmSSlk/pagoZHC2i1iqgphgl/form?prefill_Page+URL=https://docs.filecoin.io/getting-started/what-is-filecoin/retrieval-market)

--- a/getting-started/what-is-filecoin/retrieval.md
+++ b/getting-started/what-is-filecoin/retrieval.md
@@ -37,4 +37,4 @@ Use [Lassie](https://github.com/filecoin-project/lassie) for CID-based retrieval
 - [Basic retrieval](../how-retrieval-works/basic-retrieval.md) covers fetching CID-addressed data with Lassie.
 - [Serving retrievals](../how-retrieval-works/serving-retrievals.md) explains provider advertisements, IPNI, and retrieval protocols.
 
-[Was this page helpful?](https://airtable.com/apppq4inOe4gmSSlk/pagoZHC2i1iqgphgl/form?prefill_Page+URL=https://docs.filecoin.io/getting-started/what-is-filecoin/retrieval-market)
+[Was this page helpful?](https://airtable.com/apppq4inOe4gmSSlk/pagoZHC2i1iqgphgl/form?prefill_Page+URL=https://docs.filecoin.io/getting-started/what-is-filecoin/retrieval)


### PR DESCRIPTION
### Summary

- Rename the user-facing page, nav entry, and URL from "Retrieval market" / `retrieval-market` to "Retrieval" / `retrieval`.
- Add a redirect from the old `retrieval-market` path so existing links keep working.
- Restructure the overview around the main retrieval paths: Filecoin Onchain Cloud, Fil One, and direct Filecoin storage-provider retrieval.
- Update the adjacent `how-retrieval-works` pages so the implementation details line up with the overview.
- Clarify direct provider retrieval with `/piece/{pieceCid}`, `/ipfs/{cid}`, IPNI/content-routing context, and Lassie's role for CID-addressed retrieval.

### Why

FDS feedback flagged the existing retrieval page as stale. It described a narrow retrieval-deal model and did not match how users retrieve Filecoin data today. This update keeps the page introductory and gives readers a practical map of which retrieval path to use, with the implementation details handled in the existing `how-retrieval-works` section.

### Preview

- [Full GitBook preview](//docs.filecoin.io/~/revisions/CBRNaT2WBxkMoVsstHwd/)
- [GitBook diff](//app.gitbook.com/o/NNmD4UvLc26b1TmEYgzE/s/xNWFG7bQkjLkl5BBGjbD/~/diff/~/revisions/CBRNaT2WBxkMoVsstHwd/)

### Changed Pages

- [getting-started/what-is-filecoin/retrieval.md](//docs.filecoin.io/~/revisions/CBRNaT2WBxkMoVsstHwd/getting-started/what-is-filecoin/retrieval) - routes readers to the right retrieval path for Filecoin Onchain Cloud, Fil One, or direct storage-provider retrieval.
- [getting-started/how-retrieval-works/README.md](//docs.filecoin.io/~/revisions/CBRNaT2WBxkMoVsstHwd/getting-started/how-retrieval-works) - positions the section as the implementation-detail follow-up to the overview.
- [getting-started/how-retrieval-works/basic-retrieval.md](//docs.filecoin.io/~/revisions/CBRNaT2WBxkMoVsstHwd/getting-started/how-retrieval-works/basic-retrieval) - clarifies Lassie's role for CID-addressed retrieval and CAR output.
- [getting-started/how-retrieval-works/serving-retrievals.md](//docs.filecoin.io/~/revisions/CBRNaT2WBxkMoVsstHwd/getting-started/how-retrieval-works/serving-retrievals) - updates the IPNI/provider retrieval flow and separates `/piece` and `/ipfs` retrieval paths.

### Redirects

- `getting-started/what-is-filecoin/retrieval-market` -> `getting-started/what-is-filecoin/retrieval.md`
- Existing legacy redirects for `basics/what-is-filecoin/retrieval-market` and `intro/intro-to-filecoin/retrieval-market` now point at the renamed page.

### Validation

- [x] `git diff --check`
- [x] `npm run build`
- [x] GitHub `linkChecker`
- [x] GitBook preview contexts
- [ ] Link and redirect checker scripts were not run because current `filecoin-project/main` does not expose `npm run check-links` or `npm run check:redirects` as package scripts.
