### PR TITLE
docs: update Tellor contract addresses for Filecoin Mainnet

### DIFF
--- a/build/advanced/oracles.md
+++ b/build/advanced/oracles.md
@@ -56,16 +56,17 @@ Tellor supports a price feed oracle and a data oracle for the Filecoin network. 
 
 Tellor’s smart contracts are live on the Filecoin Mainnet and Calibration testnet.
 
-| Name             | Address                                      | Mainnet | Calibration |
-| ---------------- | -------------------------------------------- | ------- | ----------- |
-| Bridged TRB      | `0x045CE60839d108B43dF9e703d4b25402a6a28a0d` | ✔️      |             |
-| Playground/TRB   | `0x15e6Cc0D69A162151Cadfba035aa10b82b12b970` |         | ✔️          |
-| Oracle           | `0xb2CB696fE5244fB9004877e58dcB680cB86Ba444` | ✔️      | ✔️          |
-| Governance       | `0xb55bB55f7D8b4F26Bd18198088C96488D95cab39` | ✔️      | ✔️          |
-| Autopay          | `0x60cBf3991F05a0671250e673Aa166e9D1A0C662E` | ✔️      | ✔️          |
-| TellorFlex       | `0xb2CB696fE5244fB9004877e58dcB680cB86Ba444` | ✔️      | ✔️          |
-| QueryDataStorage | `0xf44166ca8bdB612268a4D401e4c5147968E5a190` | ✔️      | ✔️          |
-| Multisig         | `0x34Fae97547E990ef0E05e05286c51E4645bf1A85` | ✔️      | ✔️          |
+| Name                 | Filecoin Mainnet                             | Calibration                                  |
+| -------------------- | -------------------------------------------- | -------------------------------------------- |
+| Bridged TRB          | `0x045CE60839d108B43dF9e703d4b25402a6a28a0d` | —                                            |
+| Playground/TRB       | —                                            | `0x15e6Cc0D69A162151Cadfba035aa10b82b12b970` |
+| Tellor360 Oracle     | `0x8cFc184c877154a8F9ffE0fe75649dbe5e2DBEbf` | `0xb2CB696fE5244fB9004877e58dcB680cB86Ba444` |
+| Governance           | `0xB30b1B98d8276b80bC4f5aF9f9170ef3220EC27D` | `0xb55bB55f7D8b4F26Bd18198088C96488D95cab39` |
+| Autopay              | `0x3b50dEc3CA3d34d5346228D86D29CF679EAA0Ccb` | `0x60cBf3991F05a0671250e673Aa166e9D1A0C662E` |
+| QueryDataStorage (*) | `0xf44166ca8bdB612268a4D401e4c5147968E5a190` | `0xf44166ca8bdB612268a4D401e4c5147968E5a190` |
+| Multisig (*)         | `0x34Fae97547E990ef0E05e05286c51E4645bf1A85` | `0x34Fae97547E990ef0E05e05286c51E4645bf1A85` |
+
+(*) These contracts exist at the listed addresses on both networks, but they are not included in Tellor's current telliot-core contract directory.
 
 #### **Further Tellor resources**
 


### PR DESCRIPTION
## Summary

This PR updates the Tellor contract addresses documented for Filecoin Mainnet and Calibration.

The existing table uses a single address column with Mainnet and Calibration availability markers. However, Tellor uses different Oracle, Governance, and Autopay addresses on Filecoin Mainnet and Calibration. This PR therefore separates the addresses by network.

## Background

The addresses currently documented for the Oracle, Governance, and Autopay contracts correspond to Tellor's original Filecoin Calibration deployments.

On October 31, 2023, Tellor updated only the Filecoin Mainnet entries in its official `telliot-core` contract directory:

| Contract | Previous Mainnet address | Updated Mainnet address |
| -------- | ------------------------ | ----------------------- |
| Oracle | `0xb2CB696fE5244fB9004877e58dcB680cB86Ba444` | `0x8cFc184c877154a8F9ffE0fe75649dbe5e2DBEbf` |
| Governance | `0xb55bB55f7D8b4F26Bd18198088C96488D95cab39` | `0xB30b1B98d8276b80bC4f5aF9f9170ef3220EC27D` |
| Autopay | `0x60cBf3991F05a0671250e673Aa166e9D1A0C662E` | `0x3b50dEc3CA3d34d5346228D86D29CF679EAA0Ccb` |

In that update, the entries for Filecoin Mainnet, chain ID `314`, were changed, while the Filecoin Calibration entries, chain ID `314159`, remained unchanged.

The change can be verified directly in Tellor's repository:

- [tellor-io/telliot-core commit updating the Filecoin Mainnet addresses](https://github.com/tellor-io/telliot-core/commit/185089b38edd16cde50334829111e86988fd4219)

The old Mainnet contracts still have deployed bytecode, but they are no longer the canonical Mainnet addresses in Tellor's current contract directory. Therefore, checking only whether contract code exists at an address is insufficient to determine the currently supported deployment.

The Filecoin documentation was not updated after this change and currently presents the Calibration addresses as valid for both Mainnet and Calibration. This PR aligns the documentation with Tellor's current contract directory.

## Changes

- Update the Filecoin Mainnet Tellor360 Oracle address:
  - From: `0xb2CB696fE5244fB9004877e58dcB680cB86Ba444`
  - To: `0x8cFc184c877154a8F9ffE0fe75649dbe5e2DBEbf`

- Update the Filecoin Mainnet Governance address:
  - From: `0xb55bB55f7D8b4F26Bd18198088C96488D95cab39`
  - To: `0xB30b1B98d8276b80bC4f5aF9f9170ef3220EC27D`

- Update the Filecoin Mainnet Autopay address:
  - From: `0x60cBf3991F05a0671250e673Aa166e9D1A0C662E`
  - To: `0x3b50dEc3CA3d34d5346228D86D29CF679EAA0Ccb`

- Keep the existing Calibration addresses unchanged.

- Rename `Oracle` to `Tellor360 Oracle`, following the current Tellor contract directory.

- Remove the duplicate `TellorFlex` row because it refers to the same oracle deployment.

## Sources

Tellor's current contract directory lists the following Filecoin addresses:

- [Tellor360 Oracle addresses](https://github.com/tellor-io/telliot-core/blob/22ea1290e91abc8175efb962e8d8c794ea8c4c82/src/telliot_core/data/contract_directory.json#L111-L127)
- [Tellor360 Autopay addresses](https://github.com/tellor-io/telliot-core/blob/22ea1290e91abc8175efb962e8d8c794ea8c4c82/src/telliot_core/data/contract_directory.json#L168-L184)
- [TRB token addresses](https://github.com/tellor-io/telliot-core/blob/22ea1290e91abc8175efb962e8d8c794ea8c4c82/src/telliot_core/data/contract_directory.json#L225-L246)
- [Tellor Governance addresses](https://github.com/tellor-io/telliot-core/blob/22ea1290e91abc8175efb962e8d8c794ea8c4c82/src/telliot_core/data/contract_directory.json#L388-L403)

Tellor updated the Filecoin Mainnet Oracle, Autopay, and Governance addresses in this commit:

- [tellor-io/telliot-core: update Arbitrum and Filecoin addresses](https://github.com/tellor-io/telliot-core/commit/185089b38edd16cde50334829111e86988fd4219)

The previous addresses match the original Calibration deployment record:

- [Tellor on Filecoin Calibration deployment record](https://gist.github.com/trruckerfling/b304f1de5901c16867822cd2b9c086da)

Additional on-chain references:

- [QueryDataStorage on Filecoin Mainnet](https://filecoin.blockscout.com/address/0xf44166ca8bdB612268a4D401e4c5147968E5a190)
- [Multisig on Filecoin Mainnet](https://filecoin.blockscout.com/address/0x34Fae97547E990ef0E05e05286c51E4645bf1A85)
